### PR TITLE
fix: insert image_name into conversations db path

### DIFF
--- a/llama_stack/core/conversations/conversations.py
+++ b/llama_stack/core/conversations/conversations.py
@@ -47,6 +47,13 @@ class ConversationServiceConfig(BaseModel):
     )
     policy: list[AccessRule] = []
 
+    def __init__(self, run_config):
+        super().__init__(
+            conversations_store=SqliteSqlStoreConfig(
+                db_path=(DISTRIBS_BASE_DIR / run_config.image_name / "conversations.db").as_posix()
+            )
+        )
+
 
 async def get_provider_impl(config: ConversationServiceConfig, deps: dict[Any, Any]):
     """Get the conversation service implementation."""


### PR DESCRIPTION
The distro image can't write to the higher level
dir.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized conversation storage configuration to improve compatibility with various deployment environments and system setups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->