### PR TITLE
chore: Revert "chore(deps): bump next-auth from 4.24.11 to 4.24.12 in /llama_stack/ui"

### DIFF
--- a/llama_stack/ui/package-lock.json
+++ b/llama_stack/ui/package-lock.json
@@ -21,7 +21,7 @@
         "llama-stack-client": "^0.2.23",
         "lucide-react": "^0.545.0",
         "next": "15.5.4",
-        "next-auth": "^4.24.12",
+        "next-auth": "^4.24.11",
         "next-themes": "^0.4.6",
         "react": "^19.0.0",
         "react-dom": "^19.2.0",
@@ -11102,9 +11102,9 @@
       }
     },
     "node_modules/next-auth": {
-      "version": "4.24.12",
-      "resolved": "https://registry.npmjs.org/next-auth/-/next-auth-4.24.12.tgz",
-      "integrity": "sha512-wooJAL5Md9Fn2UwUI2qN9TY/+k8HJGRyi3TdSt/xHfDTtdpPxDqmo4v8hUrKGb+d66FB/rYy9RutA/9EeJrK0Q==",
+      "version": "4.24.11",
+      "resolved": "https://registry.npmjs.org/next-auth/-/next-auth-4.24.11.tgz",
+      "integrity": "sha512-pCFXzIDQX7xmHFs4KVH4luCjaCbuPRtZ9oBUjUhOk84mZ9WVPf94n87TxYI4rSRf9HmfHEF8Yep3JrYDVOo3Cw==",
       "license": "ISC",
       "dependencies": {
         "@babel/runtime": "^7.20.13",
@@ -11119,8 +11119,8 @@
       },
       "peerDependencies": {
         "@auth/core": "0.34.2",
-        "next": "^12.2.5 || ^13 || ^14 || ^15 || ^16",
-        "nodemailer": "^7.0.7",
+        "next": "^12.2.5 || ^13 || ^14 || ^15",
+        "nodemailer": "^6.6.5",
         "react": "^17.0.2 || ^18 || ^19",
         "react-dom": "^17.0.2 || ^18 || ^19"
       },

--- a/llama_stack/ui/package.json
+++ b/llama_stack/ui/package.json
@@ -26,7 +26,7 @@
     "llama-stack-client": "^0.2.23",
     "lucide-react": "^0.545.0",
     "next": "15.5.4",
-    "next-auth": "^4.24.12",
+    "next-auth": "^4.24.11",
     "next-themes": "^0.4.6",
     "react": "^19.0.0",
     "react-dom": "^19.2.0",


### PR DESCRIPTION
Reverts opendatahub-io/llama-stack#6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated authentication library to a previous stable version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->