### PR TITLE
fix: backport upstream fix for RHAIENG-2516

### DIFF
--- a/llama_stack/providers/remote/vector_io/pgvector/pgvector.py
+++ b/llama_stack/providers/remote/vector_io/pgvector/pgvector.py
@@ -336,7 +336,9 @@ class PGVectorVectorIOAdapter(OpenAIVectorStoreMixin, VectorIO, VectorStoresProt
         self.metadata_collection_name = "openai_vector_stores_metadata"
 
     async def initialize(self) -> None:
-        log.info(f"Initializing PGVector memory adapter with config: {self.config}")
+        # Create a safe config representation with masked password for logging
+        safe_config = {**self.config.model_dump(exclude={"password"}), "password": "******"}
+        log.info(f"Initializing PGVector memory adapter with config: {safe_config}")
         self.kvstore = await kvstore_impl(self.config.persistence)
         await self.initialize_openai_vector_stores()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ required-version = ">=0.7.0"
 
 [project]
 name = "llama_stack"
-version = "0.3.5+rhai0"
+version = "0.3.5.1+rhai0"
 authors = [{ name = "Meta Llama", email = "llama-oss@meta.com" }]
 description = "Llama Stack"
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -1766,7 +1766,7 @@ wheels = [
 
 [[package]]
 name = "llama-stack"
-version = "0.3.5+rhai0"
+version = "0.3.5.1+rhai0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
This backports b709bd77b into 3.2 and lays the floor for a new tag which contains 4 digits. The next new tag will be 0.3.5.1+rhai0 to indicate that it diverges from 0.3.5 and is not 0.3.6 either. We do not resync with 0.3.6 since it's not out and we will be pulling other things. We just want to produce a new tag with the blocker bug we are fixing.