### PR TITLE
chore: restore upstream comments removed during v0.4.1 merge

### DIFF
--- a/src/llama_stack/core/stack.py
+++ b/src/llama_stack/core/stack.py
@@ -452,6 +452,7 @@ def _convert_string_to_proper_type(value: str) -> Any:
     # This might be tricky depending on what the config type is, if  'str | None' we are
     # good, if 'str' we need to keep the empty string... 'str | None' is more common and
     # providers config should be typed this way.
+    # TODO: we could try to load the config class and see if the config has a field with type 'str | None'
     # and then convert the empty string to None or not
     if value == "":
         return None

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -82,6 +82,7 @@ def _track_test_context(request):
 
 
 def pytest_runtest_teardown(item):
+    # Check if the test actually ran and passed or failed, but was not skipped or an expected failure (xfail)
     outcome = getattr(item, "execution_outcome", None)
     was_xfail = getattr(item, "was_xfail", False)
 

--- a/tests/integration/fixtures/common.py
+++ b/tests/integration/fixtures/common.py
@@ -123,6 +123,7 @@ def stop_server_on_port(port: int, timeout: float = 10.0) -> None:
 
 
 def get_provider_data():
+    # TODO: this needs to be generalized so each provider can have a sample provider data just
     # like sample run config on which we can do replace_env_vars()
     keymap = {
         "TAVILY_SEARCH_API_KEY": "tavily_search_api_key",
@@ -242,6 +243,7 @@ def instantiate_llama_stack_client(session):
         # Strip the "server:" prefix first
         config_part = config[7:]  # len("server:") == 7
 
+        # Check for :: (distro::runfile format)
         if "::" in config_part:
             config_name = config_part
             port = int(os.environ.get("LLAMA_STACK_PORT", DEFAULT_PORT))
@@ -258,6 +260,7 @@ def instantiate_llama_stack_client(session):
             print(f"Forcing restart of the server on port {port}")
             stop_server_on_port(port)
 
+        # Check if port is available
         if is_port_available(port):
             print(f"Starting llama stack server with config '{config_name}' on port {port}...")
 


### PR DESCRIPTION
## Summary

While merging upstream v0.4.1, some explanatory comments were inadvertently removed. This PR restores them to maintain parity with upstream.

## Changes

- **`src/llama_stack/core/stack.py`**: Restored TODO comment about config type handling in `_convert_string_to_proper_type()`
- **`tests/integration/conftest.py`**: Restored comment explaining test outcome checking in `pytest_runtest_teardown()`
- **`tests/integration/fixtures/common.py`**: Restored TODO comment about provider data generalization and clarifying comments for config parsing logic

## Test plan

- [ ] No functional changes, comments only
- [ ] CI should pass