### PR TITLE
fix: Hardcode trust_remote_code=False

### DIFF
--- a/src/llama_stack/providers/utils/inference/embedding_mixin.py
+++ b/src/llama_stack/providers/utils/inference/embedding_mixin.py
@@ -82,7 +82,7 @@ class SentenceTransformerEmbeddingMixin:
         if loaded_model is not None:
             return loaded_model
 
-        log.info(f"Loading sentence transformer for {model}...")
+        log.info(f"Loading sentence transformer for {model}, with trust_remote_code=False for security")
 
         def _load_model():
             from sentence_transformers import SentenceTransformer
@@ -94,7 +94,7 @@ class SentenceTransformerEmbeddingMixin:
                 log.debug(f"Constraining torch threads on {platform_name} to a single worker")
                 torch.set_num_threads(1)
 
-            return SentenceTransformer(model, trust_remote_code=True)
+            return SentenceTransformer(model, trust_remote_code=False)
 
         loaded_model = await asyncio.to_thread(_load_model)
         EMBEDDING_MODELS[model] = loaded_model


### PR DESCRIPTION
All sentence-transformers now load with trust_remote_code=False to prevent RCE vulnerability.

--
Proposing we set this for 3.3 while a longer term fix is discussed in https://github.com/llamastack/llama-stack/pull/4602

Should only effect users using the inline sentence-transformers provider with models that require remote code (e.g. nomic-ai/nomic-embed-text-v1.5 ) ibm-granite/granite-embedding-125m-english would still load as expected