### PR TITLE
ci: [RHAIENG-3406] add workflow to create release branches

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -8,6 +8,7 @@ Llama Stack uses GitHub Actions for Continuous Integration (CI). Below is a tabl
 | Build Distribution Images | [build-distributions.yml](build-distributions.yml) | Build Distribution Images |
 | CI Status | [ci-status.yml](ci-status.yml) | Aggregate CI check status |
 | CodeQL Workflow Security Scan | [codeql.yml](codeql.yml) | CodeQL Workflow Security Scan |
+| Create Release Branch | [create-release-branch.yml](create-release-branch.yml) | Create release branch release-${{ inputs.product_version }} from tag ${{ inputs.tag }} |
 | Documentation Build | [docs-build.yml](docs-build.yml) | Build and validate documentation |
 | Installer CI | [install-script-ci.yml](install-script-ci.yml) | Test the installation script |
 | Integration Auth Tests | [integration-auth-tests.yml](integration-auth-tests.yml) | Run the integration test suite with Kubernetes authentication |

--- a/.github/workflows/create-release-branch.yml
+++ b/.github/workflows/create-release-branch.yml
@@ -1,0 +1,107 @@
+name: Create Release Branch
+
+run-name: Create release branch release-${{ inputs.product_version }} from tag ${{ inputs.tag }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to base the release on (e.g., v0.5.0)"
+        required: true
+        type: string
+      product_version:
+        description: "RHOAI product version (e.g., 3.4 or 3.4-EA1)"
+        required: true
+        type: string
+
+permissions: {}
+
+jobs:
+  create-release-branch:
+    runs-on: ubuntu-latest
+    env:
+      TAG: ${{ inputs.tag }}
+      PRODUCT_VERSION: ${{ inputs.product_version }}
+      BRANCH: release-${{ inputs.product_version }}
+    steps:
+      - name: Validate tag format
+        run: |
+          if [[ ! "${TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Invalid tag format '${TAG}'. Expected format: v<major>.<minor>.<patch> (e.g., v0.5.0)"
+            exit 1
+          fi
+          echo "Tag format '${TAG}' is valid"
+
+      - name: Validate product_version format
+        run: |
+          if [[ ! "${PRODUCT_VERSION}" =~ ^[0-9]+\.[0-9]+(-EA[0-9]+)?$ ]]; then
+            echo "::error::Invalid product_version format '${PRODUCT_VERSION}'. Expected format: <major>.<minor> or <major>.<minor>-EA<N> (e.g., 3.4 or 3.4-EA1)"
+            exit 1
+          fi
+          echo "product_version format '${PRODUCT_VERSION}' is valid"
+
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          token: ${{ secrets.RELEASE_TOKEN }}
+          fetch-depth: 0
+
+      - name: Validate tag exists
+        run: |
+          if ! git rev-parse "refs/tags/${TAG}" >/dev/null 2>&1; then
+            echo "::error::Tag '${TAG}' does not exist in this repository"
+            exit 1
+          fi
+          echo "Tag '${TAG}' exists"
+
+      - name: Validate release branch does not already exist
+        run: |
+          if git rev-parse --verify "refs/remotes/origin/${BRANCH}" >/dev/null 2>&1; then
+            echo "::error::Branch '${BRANCH}' already exists"
+            exit 1
+          fi
+          echo "Branch '${BRANCH}' does not exist yet"
+
+      - name: Create release branch from tag
+        run: |
+          git checkout "tags/${TAG}"
+          git checkout -b "${BRANCH}"
+          echo "Created branch '${BRANCH}' from tag '${TAG}'"
+
+      - name: Calculate project version
+        id: project-version
+        run: |
+          BASE_VERSION="${TAG#v}"
+          PROJECT_VERSION="${BASE_VERSION}+rhai0"
+          echo "project_version=${PROJECT_VERSION}" >> "${GITHUB_OUTPUT}"
+          echo "Calculated project version: ${PROJECT_VERSION}"
+
+      - name: Update pyproject.toml with pinned version
+        env:
+          PROJECT_VERSION: ${{ steps.project-version.outputs.project_version }}
+        run: |
+          sed -i 's/^dynamic = \["version"\]/version = "'"${PROJECT_VERSION}"'"/' pyproject.toml
+
+      - name: Verify pyproject.toml was updated
+        env:
+          PROJECT_VERSION: ${{ steps.project-version.outputs.project_version }}
+        run: |
+          if ! grep -q "^version = \"${PROJECT_VERSION}\"" pyproject.toml; then
+            echo "::error::Failed to update pyproject.toml. Expected line 'version = \"${PROJECT_VERSION}\"' was not found"
+            exit 1
+          fi
+          echo "pyproject.toml updated: version = \"${PROJECT_VERSION}\""
+
+      - name: Commit version change
+        env:
+          PROJECT_VERSION: ${{ steps.project-version.outputs.project_version }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add pyproject.toml
+          git commit -m "chore: set version to ${PROJECT_VERSION} for ${BRANCH}"
+
+      - name: Push release branch
+        run: |
+          git push origin "${BRANCH}"
+          echo "Successfully pushed branch '${BRANCH}'"


### PR DESCRIPTION
# What does this PR do?

Adds a manually-triggered GitHub Actions workflow that creates RHOAI release branches from upstream tags. The workflow:

- Takes `release` (e.g., `v3.4ea1`) and `tag` (e.g., `v0.5.0`) as required inputs
- Validates the release format and that the tag exists
- Creates a `release-<version>` branch from the specified tag
- Pins `version` in `pyproject.toml` (e.g., `0.5.0+rhai0`)
- Uses a PAT (`RELEASE_TOKEN`) to enable triggering downstream workflows

## Test plan

- [x] Trigger workflow with valid inputs (e.g., tag=`v0.5.0`, release=`v3.4ea1`)
- [x] Verify failure on invalid release format (e.g., `3.4ea1`)
- [x] Verify failure on non-existent tag
- [x] Verify failure when branch already exists


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a manually-triggered workflow to create release branches from tags. It validates inputs and tag existence, prevents creating an already-existing branch, computes and pins a project version, updates project metadata, commits the change, and pushes the new release branch.
* **Documentation**
  * Added README entry describing the new "Create Release Branch" workflow and how to invoke it.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->