### PR TITLE
ci: [RHAIENG-3408] add workflow to auto-tag releases

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -9,6 +9,7 @@ Llama Stack uses GitHub Actions for Continuous Integration (CI). Below is a tabl
 | CI Status | [ci-status.yml](ci-status.yml) | Aggregate CI check status |
 | CodeQL Workflow Security Scan | [codeql.yml](codeql.yml) | CodeQL Workflow Security Scan |
 | Create Release Branch | [create-release-branch.yml](create-release-branch.yml) | Create release branch release-${{ inputs.product_version }} from tag ${{ inputs.tag }} |
+| Create release tag | [create-tag.yml](create-tag.yml) | Create tag from version in pyproject.toml |
 | Documentation Build | [docs-build.yml](docs-build.yml) | Build and validate documentation |
 | Installer CI | [install-script-ci.yml](install-script-ci.yml) | Test the installation script |
 | Integration Auth Tests | [integration-auth-tests.yml](integration-auth-tests.yml) | Run the integration test suite with Kubernetes authentication |

--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -1,0 +1,81 @@
+name: Create release tag
+
+run-name: Create tag from version in pyproject.toml
+
+on:
+  push:
+    branches:
+      - "release-*"
+    paths:
+      - "pyproject.toml"
+
+permissions: {}
+
+jobs:
+  create-tag:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Extract project version from pyproject.toml
+        id: extract-project-version
+        run: |
+          PROJECT_VERSION=$(python3 -c '
+          import sys, tomllib
+
+          with open("pyproject.toml", "rb") as f:
+              data = tomllib.load(f)
+
+          project = data.get("project", {})
+
+          if "version" in project.get("dynamic", []):
+              print("version is listed in [project.dynamic] -- it must be set to a fixed value on release branches", file=sys.stderr)
+              sys.exit(1)
+
+          version = project.get("version")
+          if not version:
+              print("No version field found in [project] section of pyproject.toml", file=sys.stderr)
+              sys.exit(1)
+
+          print(version)
+          ')
+
+          if ! echo "${PROJECT_VERSION}" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(\.[0-9]+)?(\+rhai[0-9]+)?$'; then
+            echo "::error::Invalid version format: ${PROJECT_VERSION}"
+            exit 1
+          fi
+
+          echo "project-version=${PROJECT_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Extracted project version: ${PROJECT_VERSION}"
+
+      - name: Configure git credentials
+        env:
+          RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+        run: |
+          git remote set-url origin "https://x-access-token:${RELEASE_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+
+      - name: Check if tag already exists
+        id: check
+        env:
+          TAG: v${{ steps.extract-project-version.outputs.project-version }}
+        run: |
+          if git ls-remote --exit-code --tags origin "refs/tags/${TAG}" > /dev/null 2>&1; then
+            echo "::error::Tag ${TAG} already exists"
+            exit 1
+          fi
+          echo "Tag ${TAG} does not exist -- proceeding"
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+
+      - name: Create and push tag
+        id: create-tag
+        env:
+          TAG: ${{ steps.check.outputs.tag }}
+        run: |
+          git tag "${TAG}"
+          git push origin "${TAG}"
+          echo "Successfully created and pushed tag ${TAG}"


### PR DESCRIPTION
# What does this PR do?

- Add GH Actions workflow that creates a `v<version>` tag when `pyproject.toml` is modified on `release-*` branches
- Extracts the `version` field via `scripts/github/extract_version.py`, fails if version is dynamic or missing
- Uses `RELEASE_TOKEN` PAT so tag pushes can trigger downstream workflows (e.g. `pypi.yml`)
- Fails with a clear error if the tag already exists

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated CI workflow docs to describe a new automated release-tag creation process.

* **Chores**
  * Added an automated CI workflow to create release tags from the project version metadata.
  * Includes validation to detect unsupported/dynamic versioning and safeguards to prevent creating duplicate tags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->