### PR TITLE
fix: Hardcode trust_remote_code=False

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ required-version = ">=0.7.0"
 
 [project]
 name = "llama_stack"
-version = "0.5.0+rhai0"
+version = "0.5.0.1+rhai0"
 authors = [{ name = "Meta Llama", email = "llama-oss@meta.com" }]
 description = "Llama Stack"
 readme = "README.md"

--- a/src/llama_stack/providers/utils/inference/embedding_mixin.py
+++ b/src/llama_stack/providers/utils/inference/embedding_mixin.py
@@ -90,7 +90,7 @@ class SentenceTransformerEmbeddingMixin:
             if loaded_model is not None:
                 return loaded_model
 
-            log.info(f"Loading sentence transformer for {model}...")
+            log.info(f"Loading sentence transformer for {model}, with trust_remote_code=False for security")
 
             def _load_model():
                 from sentence_transformers import SentenceTransformer
@@ -102,7 +102,7 @@ class SentenceTransformerEmbeddingMixin:
                     log.debug(f"Constraining torch threads on {platform_name} to a single worker")
                     torch.set_num_threads(1)
 
-                return SentenceTransformer(model, trust_remote_code=True)
+                return SentenceTransformer(model, trust_remote_code=False)
 
             loaded_model = await asyncio.to_thread(_load_model)
             EMBEDDING_MODELS[model] = loaded_model

--- a/src/llama_stack_api/pyproject.toml
+++ b/src/llama_stack_api/pyproject.toml
@@ -7,7 +7,7 @@ required-version = ">=0.7.0"
 
 [project]
 name = "llama-stack-api"
-version = "0.5.0+rhai0"
+version = "0.5.0.1+rhai0"
 authors = [{ name = "Meta Llama", email = "llama-oss@meta.com" }]
 description = "API and Provider specifications for Llama Stack - lightweight package with protocol definitions and provider specs"
 readme = "README.md"

--- a/src/llama_stack_ui/package-lock.json
+++ b/src/llama_stack_ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "llama-stack-ui",
-  "version": "0.5.0+rhai0",
+  "version": "0.5.0.1+rhai0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "llama-stack-ui",
-      "version": "0.5.0+rhai0",
+      "version": "0.5.0.1+rhai0",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-collapsible": "^1.1.12",

--- a/src/llama_stack_ui/package.json
+++ b/src/llama_stack_ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "llama-stack-ui",
-  "version": "0.5.0+rhai0",
+  "version": "0.5.0.1+rhai0",
   "description": "Web UI for Llama Stack",
   "license": "MIT",
   "author": "Llama Stack <llamastack@meta.com>",

--- a/uv.lock
+++ b/uv.lock
@@ -2060,7 +2060,7 @@ wheels = [
 
 [[package]]
 name = "llama-stack"
-version = "0.5.0+rhai0"
+version = "0.5.0.1+rhai0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
@@ -2375,7 +2375,7 @@ unit = [
 
 [[package]]
 name = "llama-stack-api"
-version = "0.5.0+rhai0"
+version = "0.5.0.1+rhai0"
 source = { editable = "src/llama_stack_api" }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
All sentence-transformers now load with trust_remote_code=False
to prevent RCE vulnerability.


Bump version to 0.5.0.1+rhai0