### PR TITLE
ci: [RHAIENG-3410] add workflow to dispatch version updates to ODH distribution

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -10,6 +10,7 @@ Llama Stack uses GitHub Actions for Continuous Integration (CI). Below is a tabl
 | CodeQL Workflow Security Scan | [codeql.yml](codeql.yml) | CodeQL Workflow Security Scan |
 | Create Release Branch | [create-release-branch.yml](create-release-branch.yml) | Create release branch release-${{ inputs.product_version }} from tag ${{ inputs.tag }} |
 | Create release tag | [create-tag.yml](create-tag.yml) | Create tag from version in pyproject.toml |
+| Dispatch Version Update to ODH Distribution | [dispatch-version-update-to-odh-distribution.yml](dispatch-version-update-to-odh-distribution.yml) | Dispatch version update to llama-stack-distribution (${{ github.ref_name }}) |
 | Documentation Build | [docs-build.yml](docs-build.yml) | Build and validate documentation |
 | Installer CI | [install-script-ci.yml](install-script-ci.yml) | Test the installation script |
 | Integration Auth Tests | [integration-auth-tests.yml](integration-auth-tests.yml) | Run the integration test suite with Kubernetes authentication |

--- a/.github/workflows/dispatch-version-update-to-odh-distribution.yml
+++ b/.github/workflows/dispatch-version-update-to-odh-distribution.yml
@@ -1,0 +1,30 @@
+name: Dispatch Version Update to ODH Distribution
+
+run-name: "Dispatch version update to llama-stack-distribution (${{ github.ref_name }})"
+
+on:
+  push:
+    tags:
+      - 'v*\+rhai*'
+
+permissions:
+  contents: read
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send repository dispatch to llama-stack-distribution
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          TAG: ${{ github.ref_name }}
+          SOURCE_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          echo "Dispatching update-llama-stack-version with tag: ${TAG}"
+
+          gh api repos/opendatahub-io/llama-stack-distribution/dispatches \
+            -f event_type=update-llama-stack-version \
+            -f "client_payload[tag]=${TAG}" \
+            -f "client_payload[source_run_url]=${SOURCE_RUN_URL}"
+
+          echo "Dispatch sent successfully"


### PR DESCRIPTION
# What does this PR do?

- Add workflow that sends a `repository_dispatch` event to `opendatahub-io/llama-stack-distribution` when a midstream tag (`v*+rhai*`) is pushed
- The dispatch sends the new tag in the event's payload
- The dispatch triggers a version update PR in the distribution repo

## Test plan

- [ ] Push a test tag matching `v*+rhai*` and verify the dispatch is received by the distribution repo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated workflow that dispatches version-update events to the distribution repository when a release tag is pushed; logs initiation and success messages.
* **Documentation**
  * Updated CI workflow README to document the new tag-triggered dispatch workflow and its version-update process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->