### PR TITLE
ci: [RHAIENG-3409] add workflow to trigger GitLab dependency update pipeline

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -28,5 +28,6 @@ Llama Stack uses GitHub Actions for Continuous Integration (CI). Below is a tabl
 | Close stale issues and PRs | [stale_bot.yml](stale_bot.yml) | Run the Stale Bot action |
 | Test External Providers Installed via Module | [test-external-provider-module.yml](test-external-provider-module.yml) | Test External Provider installation via Python module |
 | Test External API and Providers | [test-external.yml](test-external.yml) | Test the External API and Provider mechanisms |
+| Trigger GitLab Update Release Branch Dependencies | [trigger-gitlab-update-deps.yml](trigger-gitlab-update-deps.yml) | Trigger GitLab dependency update for ${{ github.ref_name }} |
 | UI Tests | [ui-unit-tests.yml](ui-unit-tests.yml) | Run the UI test suite |
 | Unit Tests | [unit-tests.yml](unit-tests.yml) | Run the unit test suite |

--- a/.github/workflows/trigger-gitlab-update-deps.yml
+++ b/.github/workflows/trigger-gitlab-update-deps.yml
@@ -1,0 +1,83 @@
+name: Trigger GitLab Update Release Branch Dependencies
+
+run-name: Trigger GitLab dependency update for ${{ github.ref_name }}
+
+on:
+  push:
+    tags:
+      - 'v*\+rhai*'
+
+permissions: {}
+
+jobs:
+  trigger-gitlab-pipeline:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Extract product version from release branch
+        id: extract-product-version
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+
+          # Find the release branch containing the tagged commit.
+          # If multiple match, the first lexicographically is selected.
+          RELEASE_BRANCH=$(git for-each-ref --count=1 \
+            --format='%(refname:lstrip=3)' \
+            --contains="$GITHUB_SHA" \
+            'refs/remotes/origin/release-*')
+
+          if [ -z "$RELEASE_BRANCH" ]; then
+            echo "::error::No release branch found containing tag $TAG (commit $GITHUB_SHA)"
+            exit 1
+          fi
+
+          PRODUCT_VERSION="${RELEASE_BRANCH#release-}"
+          echo "product_version=$PRODUCT_VERSION" >> "$GITHUB_OUTPUT"
+          echo "Found release branch: $RELEASE_BRANCH (product_version: $PRODUCT_VERSION) for tag: $TAG"
+
+      - name: Trigger GitLab pipeline
+        env:
+          GITLAB_PIPELINE_TRIGGER_TOKEN: ${{ secrets.GITLAB_PIPELINE_TRIGGER_TOKEN }}
+          GITLAB_WHEEL_PIPELINE_PROJECT_ID: "71275045"
+          TAG: ${{ github.ref_name }}
+          PRODUCT_VERSION: ${{ steps.extract-product-version.outputs.product_version }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "$GITLAB_PIPELINE_TRIGGER_TOKEN" ]; then
+            echo "::error::GITLAB_PIPELINE_TRIGGER_TOKEN secret is not configured"
+            exit 1
+          fi
+
+          echo "Triggering GitLab pipeline to update dependencies for product_version: $PRODUCT_VERSION, tag: $TAG"
+
+          HTTP_STATUS=$(curl --silent --show-error --output response.json \
+            --write-out "%{http_code}" \
+            --connect-timeout 10 \
+            --max-time 60 \
+            --retry 3 \
+            --retry-delay 5 \
+            --retry-connrefused \
+            -X POST \
+            --form-string "token=$GITLAB_PIPELINE_TRIGGER_TOKEN" \
+            --form-string "ref=main" \
+            --form-string "variables[PIPELINE]=update-release-branch-dependencies" \
+            --form-string "variables[TAG]=$TAG" \
+            --form-string "variables[PRODUCT_VERSION]=$PRODUCT_VERSION" \
+            "https://gitlab.com/api/v4/projects/$GITLAB_WHEEL_PIPELINE_PROJECT_ID/trigger/pipeline")
+          RESPONSE_BODY=$(cat response.json)
+
+          if [ "$HTTP_STATUS" -ne 201 ]; then
+            echo "::error::Failed to trigger GitLab pipeline. HTTP status: $HTTP_STATUS"
+            echo "Response body: $RESPONSE_BODY"
+            exit 1
+          fi
+
+          echo "GitLab pipeline triggered successfully for product_version: $PRODUCT_VERSION, tag: $TAG"


### PR DESCRIPTION
# What does this PR do?

- Add GitHub Actions workflow to trigger the GitLab `update-release-branch-dependencies` pipeline when a midstream tag (`v*+rhai*`) is pushed
- The workflow determines the release name by finding the `release-v*` branch containing the tagged commit, then passes both the tag and the RHOAI version to the GitLab pipeline trigger

## Test plan

- [ ] Verify the workflow only triggers on tags matching `v*+rhai*` (not on regular `v*` tags or branch pushes)
- [ ] Push a test midstream tag to a release branch and confirm the GitLab pipeline is triggered with the correct `TAG` and `RELEASE` variables
- [ ] Confirm the workflow fails with a clear error when the tagged commit is not on any release branch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated CI workflow docs to describe a new automated release-trigger process for tagged releases.

* **Chores**
  * Added a workflow that triggers an external dependency-update pipeline when creating tagged releases, with input validation, error handling, and logging for success/failure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->