### PR TITLE
ci: copy create-tag workflow to release branch during creation

### DIFF
--- a/.github/workflows/create-release-branch.yml
+++ b/.github/workflows/create-release-branch.yml
@@ -23,6 +23,7 @@ jobs:
       TAG: ${{ inputs.tag }}
       PRODUCT_VERSION: ${{ inputs.product_version }}
       BRANCH: release-${{ inputs.product_version }}
+      CREATE_TAG_WORKFLOW: .github/workflows/create-tag.yml
     steps:
       - name: Validate tag format
         run: |
@@ -68,6 +69,29 @@ jobs:
           git checkout -b "${BRANCH}"
           echo "Created branch '${BRANCH}' from tag '${TAG}'"
 
+      - name: Configure git user
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Copy create-tag workflow from main
+        run: |
+          if ! git show "origin/main:${CREATE_TAG_WORKFLOW}" >/dev/null 2>&1; then
+            echo "::error::${CREATE_TAG_WORKFLOW} not found on main branch"
+            exit 1
+          fi
+          git checkout origin/main -- "${CREATE_TAG_WORKFLOW}"
+          echo "Copied ${CREATE_TAG_WORKFLOW} from main to release branch"
+
+      - name: Commit create-tag workflow
+        run: |
+          git add "${CREATE_TAG_WORKFLOW}"
+          if git diff --cached --quiet -- "${CREATE_TAG_WORKFLOW}"; then
+            echo "${CREATE_TAG_WORKFLOW} already up to date, skipping commit"
+          else
+            git commit -m "ci: add create-tag workflow to ${BRANCH}"
+          fi
+
       - name: Calculate project version
         id: project-version
         run: |
@@ -96,8 +120,6 @@ jobs:
         env:
           PROJECT_VERSION: ${{ steps.project-version.outputs.project_version }}
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
           git add pyproject.toml
           git commit -m "chore: set version to ${PROJECT_VERSION} for ${BRANCH}"
 


### PR DESCRIPTION
Tags synced from upstream don't include our custom create-tag.yml workflow. Since the create-release-branch workflow creates branches from these upstream tags, the resulting release branches lack the workflow file. Without it, the push trigger on `release-*` branches with pyproject.toml changes never fires, and tags are not auto-created.

The fix: copy create-tag.yml from origin/main onto the release branch and commit it before pushing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated release branch creation workflow to set a repository commit identity, copy the tag-creation workflow into the release branch, and commit it only when needed.
  * Removed redundant git configuration commands from the final commit step.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->