### PR TITLE
fix:  cherry-picks and bump to 0.6.0.1

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -8,6 +8,7 @@ Llama Stack uses GitHub Actions for Continuous Integration (CI). Below is a tabl
 | Build Distribution Images | [build-distributions.yml](build-distributions.yml) | Build Distribution Images |
 | CI Status | [ci-status.yml](ci-status.yml) | Aggregate CI check status |
 | CodeQL Workflow Security Scan | [codeql.yml](codeql.yml) | CodeQL Workflow Security Scan |
+| Create release tag | [create-tag.yml](create-tag.yml) | Create tag from version in pyproject.toml |
 | Documentation Build | [docs-build.yml](docs-build.yml) | Build and validate documentation |
 | Installer CI | [install-script-ci.yml](install-script-ci.yml) | Test the installation script |
 | Integration Auth Tests | [integration-auth-tests.yml](integration-auth-tests.yml) | Run the integration test suite with Kubernetes authentication |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ required-version = ">=0.7.0"
 
 [project]
 name = "llama_stack"
-version = "0.6.0+rhai0"
+version = "0.6.0.1+rhai0"
 authors = [{ name = "Meta Llama", email = "llama-oss@meta.com" }]
 description = "Llama Stack"
 readme = "README.md"

--- a/src/llama_stack/core/server/server.py
+++ b/src/llama_stack/core/server/server.py
@@ -112,11 +112,9 @@ class StackApp(FastAPI):
         super().__init__(*args, **kwargs)
         self.stack: Stack = Stack(config)
 
-        # This code is called from a running event loop managed by uvicorn so we cannot simply call
-        # asyncio.run() to initialize the stack. We cannot await either since this is not an async
-        # function.
-        # As a workaround, we use a thread pool executor to run the initialize() method
-        # in a separate thread.
+        # Initialize stack in a temporary event loop to set up impls for route registration.
+        # Storage backends use lazy engine initialization, so connections are created on
+        # first use in the correct event loop, avoiding event loop mismatch issues.
         with concurrent.futures.ThreadPoolExecutor() as executor:
             future = executor.submit(asyncio.run, self.stack.initialize())
             future.result()

--- a/src/llama_stack/core/storage/sqlstore/sqlalchemy_sqlstore.py
+++ b/src/llama_stack/core/storage/sqlstore/sqlalchemy_sqlstore.py
@@ -72,9 +72,34 @@ class SqlAlchemySqlStoreImpl(SqlStore):
     def __init__(self, config: SqlAlchemySqlStoreConfig):
         self.config = config
         self._is_sqlite_backend = "sqlite" in self.config.engine_str
-        self._engine = self.create_engine()
-        self.async_session = async_sessionmaker(self._engine)
+        self._engine: AsyncEngine | None = None  # Lazy initialization
+        self.async_session = None
         self.metadata = MetaData()
+        self._pending_columns: dict[
+            str, list[tuple[str, ColumnType, bool]]
+        ] = {}  # table -> [(col_name, col_type, nullable)]
+
+    async def _ensure_engine(self):
+        """Lazy initialization: create engine on first use in the current event loop.
+
+        This fixes event loop mismatch issues when Stack is initialized in a different
+        event loop (e.g., ThreadPoolExecutor) than request handling (uvicorn's loop).
+        """
+        if self._engine is None:
+            # Create engine in the current running event loop
+            self._engine = self.create_engine()
+            self.async_session = async_sessionmaker(self._engine)
+
+            # Create all tables that were registered during initialization
+            if self.metadata.tables:
+                async with self._engine.begin() as conn:
+                    await conn.run_sync(self.metadata.create_all, checkfirst=True)
+
+            # Add all pending columns that were queued during initialization
+            for table_name, columns in self._pending_columns.items():
+                for col_name, col_type, nullable in columns:
+                    await self._add_column_now(table_name, col_name, col_type, nullable)
+            self._pending_columns.clear()
 
     async def shutdown(self):
         """Dispose of the async engine and close all connections."""
@@ -119,6 +144,8 @@ class SqlAlchemySqlStoreImpl(SqlStore):
         table: str,
         schema: Mapping[str, ColumnType | ColumnDefinition],
     ) -> None:
+        # Don't create engine yet - just store table metadata
+        # Engine will be created on first data operation
         if not schema:
             raise ValueError(f"No columns defined for table '{table}'.")
 
@@ -144,15 +171,14 @@ class SqlAlchemySqlStoreImpl(SqlStore):
                 Column(col_name, sqlalchemy_type, primary_key=is_primary_key, nullable=is_nullable)
             )
 
+        # Register table in metadata - actual creation happens in _ensure_engine()
         if table not in self.metadata.tables:
-            sqlalchemy_table = Table(table, self.metadata, *sqlalchemy_columns)
-        else:
-            sqlalchemy_table = self.metadata.tables[table]
-
-        async with self._engine.begin() as conn:
-            await conn.run_sync(self.metadata.create_all, tables=[sqlalchemy_table], checkfirst=True)
+            Table(table, self.metadata, *sqlalchemy_columns)
+        # If table already exists in metadata, we're done (no need to recreate)
 
     async def insert(self, table: str, data: Mapping[str, Any] | Sequence[Mapping[str, Any]]) -> None:
+        await self._ensure_engine()  # Lazy init in current event loop
+        assert self.async_session is not None  # _ensure_engine guarantees this
         async with self.async_session() as session:
             await session.execute(self.metadata.tables[table].insert(), data)
             await session.commit()
@@ -164,6 +190,8 @@ class SqlAlchemySqlStoreImpl(SqlStore):
         conflict_columns: list[str],
         update_columns: list[str] | None = None,
     ) -> None:
+        await self._ensure_engine()  # Lazy init in current event loop
+        assert self.async_session is not None  # _ensure_engine guarantees this
         table_obj = self.metadata.tables[table]
         dialect_insert = self._get_dialect_insert(table_obj)
         insert_stmt = dialect_insert.values(**data)
@@ -190,6 +218,8 @@ class SqlAlchemySqlStoreImpl(SqlStore):
         order_by: list[tuple[str, Literal["asc", "desc"]]] | None = None,
         cursor: tuple[str, str] | None = None,
     ) -> PaginatedResponse:
+        await self._ensure_engine()  # Lazy init in current event loop
+        assert self.async_session is not None  # _ensure_engine guarantees this
         async with self.async_session() as session:
             table_obj = self.metadata.tables[table]
             query = select(table_obj)
@@ -303,6 +333,8 @@ class SqlAlchemySqlStoreImpl(SqlStore):
         data: Mapping[str, Any],
         where: Mapping[str, Any],
     ) -> None:
+        await self._ensure_engine()  # Lazy init in current event loop
+        assert self.async_session is not None  # _ensure_engine guarantees this
         if not where:
             raise ValueError("where is required for update")
 
@@ -314,6 +346,8 @@ class SqlAlchemySqlStoreImpl(SqlStore):
             await session.commit()
 
     async def delete(self, table: str, where: Mapping[str, Any]) -> None:
+        await self._ensure_engine()  # Lazy init in current event loop
+        assert self.async_session is not None  # _ensure_engine guarantees this
         if not where:
             raise ValueError("where is required for delete")
 
@@ -331,7 +365,25 @@ class SqlAlchemySqlStoreImpl(SqlStore):
         column_type: ColumnType,
         nullable: bool = True,
     ) -> None:
-        """Add a column to an existing table if the column doesn't already exist."""
+        """Queue a column to be added when engine is created, or add it now if engine exists."""
+        if self._engine is None:
+            # Engine not created yet - queue this column addition for later
+            if table not in self._pending_columns:
+                self._pending_columns[table] = []
+            self._pending_columns[table].append((column_name, column_type, nullable))
+        else:
+            # Engine already exists - add column immediately
+            await self._add_column_now(table, column_name, column_type, nullable)
+
+    async def _add_column_now(
+        self,
+        table: str,
+        column_name: str,
+        column_type: ColumnType,
+        nullable: bool = True,
+    ) -> None:
+        """Actually add a column to an existing table if the column doesn't already exist."""
+        assert self._engine is not None  # Only called when engine exists
         try:
             async with self._engine.begin() as conn:
 

--- a/src/llama_stack/providers/utils/inference/embedding_mixin.py
+++ b/src/llama_stack/providers/utils/inference/embedding_mixin.py
@@ -90,7 +90,7 @@ class SentenceTransformerEmbeddingMixin:
             if loaded_model is not None:
                 return loaded_model
 
-            log.info(f"Loading sentence transformer for {model}...")
+            log.info(f"Loading sentence transformer for {model}, with trust_remote_code=False for security")
 
             def _load_model():
                 from sentence_transformers import SentenceTransformer
@@ -102,7 +102,7 @@ class SentenceTransformerEmbeddingMixin:
                     log.debug(f"Constraining torch threads on {platform_name} to a single worker")
                     torch.set_num_threads(1)
 
-                return SentenceTransformer(model, trust_remote_code=True)
+                return SentenceTransformer(model, trust_remote_code=False)
 
             loaded_model = await asyncio.to_thread(_load_model)
             EMBEDDING_MODELS[model] = loaded_model

--- a/tests/unit/core/test_storage_shutdown.py
+++ b/tests/unit/core/test_storage_shutdown.py
@@ -120,16 +120,16 @@ class TestSqlStoreShutdown:
             config = SqliteSqlStoreConfig(db_path=f"{tmpdir}/test.db")
             store = SqlAlchemySqlStoreImpl(config)
 
-            # Verify session maker has an engine
-            assert store.async_session is not None
-            engine = store.async_session.kw.get("bind")
-            assert engine is not None
-
-            # Create a table and insert data
+            # Create a table and insert data (this triggers lazy engine initialization)
             from llama_stack_api.internal.sqlstore import ColumnType
 
             await store.create_table("test", {"id": ColumnType.INTEGER, "name": ColumnType.STRING})
             await store.insert("test", {"id": 1, "name": "test"})
+
+            # Verify session maker has an engine (after lazy init)
+            assert store.async_session is not None
+            engine = store.async_session.kw.get("bind")
+            assert engine is not None
 
             # Shutdown
             await store.shutdown()

--- a/tests/unit/utils/sqlstore/test_sqlstore.py
+++ b/tests/unit/utils/sqlstore/test_sqlstore.py
@@ -25,15 +25,16 @@ async def test_sqlstore_shutdown_disposes_engine():
         db_path = tmp_dir + "/shutdown_test.db"
         store = SqlAlchemySqlStoreImpl(SqliteSqlStoreConfig(db_path=db_path))
 
-        # Verify engine exists
-        assert store._engine is not None
-
         # Create a table and insert data to ensure connections are established
+        # (this triggers lazy engine initialization)
         await store.create_table(
             "test",
             {"id": ColumnType.INTEGER, "name": ColumnType.STRING},
         )
         await store.insert("test", {"id": 1, "name": "test"})
+
+        # Verify engine exists (after lazy init)
+        assert store._engine is not None
 
         # Shutdown should dispose the engine and close connections
         await store.shutdown()

--- a/uv.lock
+++ b/uv.lock
@@ -2051,6 +2051,7 @@ wheels = [
 
 [[package]]
 name = "llama-stack"
+version = "0.6.0.1+rhai0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
@@ -2224,7 +2225,7 @@ requires-dist = [
     { name = "jinja2", specifier = ">=3.1.6" },
     { name = "jsonschema" },
     { name = "llama-stack-api", editable = "src/llama_stack_api" },
-    { name = "llama-stack-client", marker = "extra == 'client'", specifier = ">=0.4.0.dev0" },
+    { name = "llama-stack-client", marker = "extra == 'client'", specifier = "==0.6.0" },
     { name = "mcp", specifier = ">=1.23.0" },
     { name = "numpy", specifier = ">=2.3.2" },
     { name = "oci", specifier = ">=2.165.0" },
@@ -2323,7 +2324,7 @@ type-checking = [
     { name = "datasets" },
     { name = "fairscale" },
     { name = "faiss-cpu" },
-    { name = "llama-stack-client", specifier = ">=0.3.0" },
+    { name = "llama-stack-client", specifier = "==0.6.0" },
     { name = "lm-format-enforcer" },
     { name = "mcp", specifier = ">=1.23.0" },
     { name = "nest-asyncio" },
@@ -2391,7 +2392,7 @@ requires-dist = [
 
 [[package]]
 name = "llama-stack-client"
-version = "0.4.1"
+version = "0.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -2410,9 +2411,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ff/42/5fb9feec3aa05958904fe507323fb180b781b7293a0f8ea17072010b7860/llama_stack_client-0.4.1.tar.gz", hash = "sha256:30577d3c94edbe388e67443cb7af4c5f76b267e92aed127d36d1d968d4510aec", size = 352966, upload-time = "2026-01-13T15:12:17.352Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b7/e9/62dc71e7d6003d9b56a1e632445065f55687c891e62eff1636e10b5dd629/llama_stack_client-0.6.0.tar.gz", hash = "sha256:3290aac36dcafbd1bc0baaf995522e2037f57056672b5a1516af112a4210f3ea", size = 368695, upload-time = "2026-03-11T15:04:19.267Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d4/d6/67d51d546298c8f43ba2fc19cf970678697d014a762e79869c208606f075/llama_stack_client-0.4.1-py3-none-any.whl", hash = "sha256:5ba0cbf1c98d083ab99d46a1ba2b47f7114a12b35366bf733f614d3ec4ff33d6", size = 375941, upload-time = "2026-01-13T15:12:15.751Z" },
+    { url = "https://files.pythonhosted.org/packages/83/a3/33d3e066a320a993b6f9cca9c8efe8da7deb2045df61235d327d0a05b25f/llama_stack_client-0.6.0-py3-none-any.whl", hash = "sha256:7e514a6ffd92f237aceb062dadc4db44e24a3cd9c4ea35e25173d1e0739beb8e", size = 392001, upload-time = "2026-03-11T15:04:17.772Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Includes
- bump in version to 0.6.0.1
- fix(storage): resolve asyncio event loop mismatch via operation deferral (https://github.com/llamastack/llama-stack/pull/5130)
- fix: Hardcode trust_remote_code=False

