### PR TITLE
fix: remove eval API references from distribution docs (RHAIENG-4432)

### DIFF
--- a/docs/docs/distributions/self_hosted_distro/nvidia.md
+++ b/docs/docs/distributions/self_hosted_distro/nvidia.md
@@ -60,12 +60,6 @@ The NeMo Data Store microservice serves as the default file storage solution for
 
 See the [NVIDIA Datasetio docs](https://github.com/meta-llama/llama-stack/blob/main/llama_stack/providers/remote/datasetio/nvidia/README.md) for supported features and example usage.
 
-### Eval API: NeMo Evaluator
-
-The NeMo Evaluator microservice supports evaluation of LLMs. Launching an Evaluation job with NeMo Evaluator requires an Evaluation Config (an object that contains metadata needed by the job). A Llama Stack Benchmark maps to an Evaluation Config, so registering a Benchmark creates an Evaluation Config in NeMo Evaluator. The `NVIDIA_EVALUATOR_URL` environment variable should point to your NeMo Microservices endpoint.
-
-See the [NVIDIA Eval docs](https://github.com/meta-llama/llama-stack/blob/main/llama_stack/providers/remote/eval/nvidia/README.md) for supported features and example usage.
-
 ### Safety API: NeMo Guardrails
 
 The NeMo Guardrails microservice sits between your application and the LLM, and adds checks and content moderation to a model. The `GUARDRAILS_SERVICE_URL` environment variable should point to your NeMo Microservices endpoint.

--- a/src/llama_stack/distributions/nvidia/doc_template.md
+++ b/src/llama_stack/distributions/nvidia/doc_template.md
@@ -55,12 +55,6 @@ The NeMo Data Store microservice serves as the default file storage solution for
 
 See the [NVIDIA Datasetio docs](https://github.com/meta-llama/llama-stack/blob/main/llama_stack/providers/remote/datasetio/nvidia/README.md) for supported features and example usage.
 
-### Eval API: NeMo Evaluator
-
-The NeMo Evaluator microservice supports evaluation of LLMs. Launching an Evaluation job with NeMo Evaluator requires an Evaluation Config (an object that contains metadata needed by the job). A Llama Stack Benchmark maps to an Evaluation Config, so registering a Benchmark creates an Evaluation Config in NeMo Evaluator. The `NVIDIA_EVALUATOR_URL` environment variable should point to your NeMo Microservices endpoint.
-
-See the [NVIDIA Eval docs](https://github.com/meta-llama/llama-stack/blob/main/llama_stack/providers/remote/eval/nvidia/README.md) for supported features and example usage.
-
 ### Safety API: NeMo Guardrails
 
 The NeMo Guardrails microservice sits between your application and the LLM, and adds checks and content moderation to a model. The `GUARDRAILS_SERVICE_URL` environment variable should point to your NeMo Microservices endpoint.

--- a/src/llama_stack/distributions/nvidia/nvidia.py
+++ b/src/llama_stack/distributions/nvidia/nvidia.py
@@ -20,7 +20,7 @@ def get_distribution_template(name: str = "nvidia") -> DistributionTemplate:
         name: the distribution name.
 
     Returns:
-        A DistributionTemplate configured for NVIDIA NIM inference, eval, and safety.
+        A DistributionTemplate configured for NVIDIA NIM inference and safety.
     """
     providers = {
         "inference": [BuildProvider(provider_type="remote::nvidia")],

--- a/src/llama_stack/distributions/open-benchmark/open_benchmark.py
+++ b/src/llama_stack/distributions/open-benchmark/open_benchmark.py
@@ -96,7 +96,7 @@ def get_inference_providers() -> tuple[list[Provider], dict[str, list[ProviderMo
 
 
 def get_distribution_template() -> DistributionTemplate:
-    """Build the open-benchmark distribution template for running evaluations.
+    """Build the open-benchmark distribution template.
 
     Returns:
         A DistributionTemplate configured for open benchmarking.


### PR DESCRIPTION
 ## Test Plan

  This is a documentation-only change. No functional code was modified.

  1. Verified no eval/scoring/benchmark references remain in distribution config files
  2. Distribution template codegen pre-commit hook passes (regenerated nvidia.md automatically)
  3. All other pre-commit hooks pass (mypy, ruff, markdownlint)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed NeMo Evaluator documentation section from NVIDIA distribution guide, including environment variable configuration and evaluation job launch instructions.
  * Updated distribution documentation to clarify that NVIDIA NIM distribution is configured for inference and safety capabilities only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->