### PR TITLE
chore: merge upstream v1.1.1 into release-3.5-ea.2

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -21,6 +21,8 @@ OGX uses GitHub Actions for Continuous Integration (CI). Below is a table detail
 | Messages API - Claude Code Client Smoke Tests | [integration-tests-messages-clients.yml](integration-tests-messages-clients.yml) | Drive the Claude Code CLI and Agent SDK against /v1/messages (live, Ollama) |
 | Integration Tests (Replay) | [integration-tests.yml](integration-tests.yml) | Run the integration test suites from tests/integration in replay mode |
 | Vector IO Integration Tests | [integration-vector-io-tests.yml](integration-vector-io-tests.yml) | Run the integration test suite with various VectorIO providers |
+| Create release tag | [odh-create-tag.yml](odh-create-tag.yml) | Create tag from version in pyproject.toml |
+| Dispatch Version Update to ODH Distribution | [odh-dispatch-version-update-to-odh-distribution.yml](odh-dispatch-version-update-to-odh-distribution.yml) | Dispatch version update to llama-stack-distribution (${{ github.ref_name }}) |
 | OpenAPI Generator SDK Validation | [openapi-generator-validation.yml](openapi-generator-validation.yml) | Validate OpenAPI Generator SDK generation |
 | OpenResponses Conformance Tests | [openresponses-conformance.yml](openresponses-conformance.yml) | Run OpenResponses conformance tests against ogx Responses API |
 | Post-release automation | [post-release.yml](post-release.yml) | Post-release automation |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ constraint-dependencies = [
 
 [project]
 name = "ogx"
-version = "1.1.0+rhaiv.0"
+version = "1.1.1+rhaiv.0"
 authors = [{ name = "The OGX Contributors", email = "contributors@ogx.dev" }]
 description = "Open-source, OpenAI-compatible API server with pluggable providers for any model and any infrastructure"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=61.0", "setuptools-scm>=8.0"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]
-fallback_version = "1.1.0"
+fallback_version = "1.1.1"
 
 [tool.uv]
 required-version = ">=0.7.0"
@@ -80,7 +80,7 @@ dependencies = [
 
 [project.optional-dependencies]
 client = [
-    "ogx-client==1.1.0", # Optional for library-only usage
+    "ogx-client==1.1.1", # Optional for library-only usage
 ]
 starter = [
     "aiohttp",
@@ -144,7 +144,7 @@ dev = [
     "pre-commit>=4.4.0",
     "ruamel.yaml",                   # needed for openapi generator
     "openapi-spec-validator>=0.9.0",
-    "ogx-client==1.1.0",
+    "ogx-client==1.1.1",
     "boto3>=1.43.18",
     "torch>=2.6.0",
 ]
@@ -183,7 +183,7 @@ type_checking = [
     "langchain-openai>=1.2.2",
     "langchain-core",
     "langgraph",
-    "ogx-client==1.1.0",
+    "ogx-client==1.1.1",
 ]
 test-common = [
     "aiohttp",

--- a/src/ogx/core/server/server.py
+++ b/src/ogx/core/server/server.py
@@ -147,6 +147,17 @@ class StackApp(FastAPI):
 
         reset_sqlstore_engines()
 
+        # Reset VertexAI provider clients that may have been created in the
+        # temporary event loop during model listing (refresh_registry_once).
+        # Like SQL engines, the Google genai Client eagerly binds an internal
+        # httpx.AsyncClient to the current event loop, and the cached client
+        # becomes unusable after the temporary loop is terminated.
+        if self.stack.impls:
+            for impl in self.stack.impls.values():
+                reset_fn = getattr(impl, "_reset_client", None)
+                if reset_fn is not None:
+                    reset_fn()
+
 
 @asynccontextmanager
 async def lifespan(app: StackApp) -> AsyncIterator[None]:

--- a/src/ogx/providers/inline/file_processor/docling/docling.py
+++ b/src/ogx/providers/inline/file_processor/docling/docling.py
@@ -4,8 +4,10 @@
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
 
+import asyncio
 import os
 import tempfile
+import threading
 import time
 import uuid
 from typing import Any
@@ -49,6 +51,7 @@ class DoclingFileProcessor:
         self.converter = DocumentConverter(
             format_options={InputFormat.PDF: PdfFormatOption(pipeline_options=pipeline_options)}
         )
+        self._converter_lock = threading.Lock()
 
     async def process_file(
         self,
@@ -80,13 +83,25 @@ class DoclingFileProcessor:
             )
             content = content_response.body
 
+        return await asyncio.to_thread(self._process_content, content, filename, file_id, chunking_strategy, start_time)
+
+    def _process_content(
+        self,
+        content: bytes,
+        filename: str,
+        file_id: str | None,
+        chunking_strategy: VectorStoreChunkingStrategy | None,
+        start_time: float,
+    ) -> ProcessFileResponse:
+        """Convert and chunk file content. Runs in a thread."""
         # Preserve original file extension so DocumentConverter can detect the format
         suffix = os.path.splitext(filename)[1] or ".bin"
         with tempfile.NamedTemporaryFile(suffix=suffix, delete=True) as tmp:
             tmp.write(content)
             tmp.flush()
 
-            result = self.converter.convert(tmp.name)
+            with self._converter_lock:
+                result = self.converter.convert(tmp.name)
 
         doc = result.document
         page_count = doc.num_pages()

--- a/src/ogx/providers/inline/file_processor/markitdown/markitdown_processor.py
+++ b/src/ogx/providers/inline/file_processor/markitdown/markitdown_processor.py
@@ -4,8 +4,10 @@
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
 
+import asyncio
 import os
 import tempfile
+import threading
 import time
 import uuid
 from typing import Any
@@ -40,6 +42,7 @@ class MarkItDownFileProcessor:
         self.config = config
         self.files_api = files_api
         self.converter = MarkItDown()
+        self._converter_lock = threading.Lock()
 
     async def process_file(
         self,
@@ -69,13 +72,25 @@ class MarkItDownFileProcessor:
             )
             content = content_response.body
 
+        return await asyncio.to_thread(self._process_content, content, filename, file_id, chunking_strategy, start_time)
+
+    def _process_content(
+        self,
+        content: bytes,
+        filename: str,
+        file_id: str | None,
+        chunking_strategy: VectorStoreChunkingStrategy | None,
+        start_time: float,
+    ) -> ProcessFileResponse:
+        """Convert and chunk file content. Runs in a thread."""
         suffix = os.path.splitext(filename)[1] or ".bin"
         with tempfile.NamedTemporaryFile(suffix=suffix, delete=True) as tmp:
             tmp.write(content)
             tmp.flush()
 
             try:
-                result = self.converter.convert(tmp.name)
+                with self._converter_lock:
+                    result = self.converter.convert(tmp.name)
             except Exception as e:
                 raise HTTPException(
                     status_code=422,

--- a/src/ogx/providers/inline/file_processor/pypdf/pypdf.py
+++ b/src/ogx/providers/inline/file_processor/pypdf/pypdf.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
 
+import asyncio
 import io
 import mimetypes
 import time
@@ -74,9 +75,11 @@ class PyPDFFileProcessor:
         mime_category = mime_type.split("/")[0] if (mime_type and "/" in mime_type) else None
 
         if mime_type == "application/pdf":
-            return self._process_pdf(content, filename, file_id, chunking_strategy, start_time)
+            return await asyncio.to_thread(self._process_pdf, content, filename, file_id, chunking_strategy, start_time)
         elif mime_category == "text":
-            return self._process_text(content, filename, file_id, chunking_strategy, start_time)
+            return await asyncio.to_thread(
+                self._process_text, content, filename, file_id, chunking_strategy, start_time
+            )
         else:
             raise HTTPException(
                 status_code=422,

--- a/src/ogx/providers/remote/inference/vertexai/vertexai.py
+++ b/src/ogx/providers/remote/inference/vertexai/vertexai.py
@@ -202,6 +202,29 @@ class VertexAIInferenceAdapter(NeedsRequestProviderData, BaseModel):
                 exc_info=True,
             )
 
+    def _reset_client(self) -> None:
+        """Reset cached client and HTTP options after a temporary event loop exits.
+
+        When StackApp.__init__ runs stack.initialize() inside a temporary event
+        loop (via ThreadPoolExecutor), model listing may trigger lazy client
+        creation via _get_client().  The Google genai Client eagerly creates an
+        internal httpx.AsyncClient bound to the temporary loop.  After the
+        temporary loop is closed, the cached client holds connections tied to
+        the dead loop, causing ``RuntimeError: Event loop is closed`` on the
+        first inference request.
+
+        This method clears the cached client without awaiting async close
+        (the temporary loop is already terminated) so that a fresh client is
+        created on the next _get_client() call — this time on uvicorn's
+        request-handling event loop.
+
+        Compare ``reset_sqlstore_engines()`` which serves the same purpose for
+        SQL engines.
+        """
+        self._default_client = None
+        self._http_options = None
+        self._http_options_initialized = False
+
     async def shutdown(self) -> None:
         await self._close_managed_httpx_client()
         self._http_options = None
@@ -315,7 +338,30 @@ class VertexAIInferenceAdapter(NeedsRequestProviderData, BaseModel):
                 access_token = self.config.auth_credential.get_secret_value() if self.config.auth_credential else None
                 return self._create_client(project=project, location=location, access_token=access_token)
 
-        # Lazily create the default client on first use
+        # Lazily create the default client on first use.
+        # If we already have a cached client, verify it is still usable before
+        # returning it — a previous request may have left connections tied to an
+        # event loop that is now closed (e.g., after a temporary startup loop).
+        if self._default_client is not None:
+            try:
+                # Touch the underlying httpx client to detect event loop binding
+                # issues.  If the client was created in a now-closed loop,
+                # accessing its transport raises RuntimeError.
+                if self._http_options is not None:
+                    _client = getattr(self._http_options, "httpx_async_client", None)
+                    if _client is not None and _client.is_closed:
+                        logger.info(
+                            "VertexAI default client transport is closed; recreating",
+                            project=self.config.project,
+                        )
+                        self._default_client = None
+            except RuntimeError:
+                logger.warning(
+                    "VertexAI default client is bound to a closed event loop; recreating",
+                    project=self.config.project,
+                )
+                self._default_client = None
+
         if self._default_client is None:
             access_token = self.config.auth_credential.get_secret_value() if self.config.auth_credential else None
             try:

--- a/src/ogx/providers/remote/vector_io/milvus/milvus.py
+++ b/src/ogx/providers/remote/vector_io/milvus/milvus.py
@@ -238,7 +238,7 @@ class MilvusIndex(EmbeddingIndex):
             "data": [embedding],
             "anns_field": "vector",
             "limit": k,
-            "output_fields": ["*"],
+            "output_fields": ["chunk_content"],
         }
 
         # Only apply radius threshold if score_threshold is meaningful

--- a/src/ogx/providers/remote/vector_io/qdrant/qdrant.py
+++ b/src/ogx/providers/remote/vector_io/qdrant/qdrant.py
@@ -133,6 +133,12 @@ class QdrantIndex(EmbeddingIndex):
         if filters is not None:
             raise NotImplementedError("Qdrant provider does not yet support native filtering")
 
+        # Collections are created lazily on first insert, so a search against a
+        # store that has never had chunks added has no collection yet. Treat that
+        # as an empty result rather than letting Qdrant raise a 404.
+        if not await self.client.collection_exists(self.collection_name):
+            return QueryChunksResponse(chunks=[], scores=[])
+
         results = (
             await self.client.query_points(
                 collection_name=self.collection_name,
@@ -183,6 +189,12 @@ class QdrantIndex(EmbeddingIndex):
         # Qdrant provider does not yet support native filtering
         if filters is not None:
             raise NotImplementedError("Qdrant provider does not yet support native filtering")
+
+        # Collections are created lazily on first insert, so a search against a
+        # store that has never had chunks added has no collection yet. Treat that
+        # as an empty result rather than letting Qdrant raise a 404.
+        if not await self.client.collection_exists(self.collection_name):
+            return QueryChunksResponse(chunks=[], scores=[])
 
         try:
             # Use scroll for keyword-only search since query_points requires a query vector
@@ -263,6 +275,12 @@ class QdrantIndex(EmbeddingIndex):
         # Qdrant provider does not yet support native filtering
         if filters is not None:
             raise NotImplementedError("Qdrant provider does not yet support native filtering")
+
+        # Collections are created lazily on first insert, so a search against a
+        # store that has never had chunks added has no collection yet. Treat that
+        # as an empty result rather than letting Qdrant raise a 404.
+        if not await self.client.collection_exists(self.collection_name):
+            return QueryChunksResponse(chunks=[], scores=[])
 
         try:
             query_words = query_string.lower().split()

--- a/src/ogx/providers/utils/memory/openai_vector_store_mixin.py
+++ b/src/ogx/providers/utils/memory/openai_vector_store_mixin.py
@@ -1121,14 +1121,8 @@ class OpenAIVectorStoreMixin(ABC):
             )
 
         except Exception as e:
-            # Log the error and return empty results
-            logger.error("Error searching vector store", vector_store_id=vector_store_id, error=str(e))
-            return VectorStoreSearchResponsePage(
-                search_query=request.query if isinstance(request.query, list) else [request.query],
-                data=[],
-                has_more=False,
-                next_page=None,
-            )
+            logger.error("Failed to search vector store", vector_store_id=vector_store_id, error=str(e))
+            raise
 
     def _build_reranker_params(
         self,

--- a/src/ogx_api/pyproject.toml
+++ b/src/ogx_api/pyproject.toml
@@ -96,7 +96,7 @@ ogx_api = ["py.typed", "**/*.json", "**/*.yaml"]
 
 [tool.setuptools_scm]
 root = "../.."
-fallback_version = "1.1.0"
+fallback_version = "1.1.1"
 
 [tool.ruff]
 line-length = 120

--- a/src/ogx_api/pyproject.toml
+++ b/src/ogx_api/pyproject.toml
@@ -14,7 +14,7 @@ constraint-dependencies = [
 
 [project]
 name = "ogx-api"
-version = "1.1.0+rhaiv.0"
+version = "1.1.1+rhaiv.0"
 authors = [{ name = "The OGX Contributors", email = "contributors@ogx.dev" }]
 description = "API and Provider specifications for OGX - lightweight package with protocol definitions and provider specs"
 readme = "README.md"

--- a/src/ogx_ui/package-lock.json
+++ b/src/ogx_ui/package-lock.json
@@ -26,7 +26,7 @@
         "next": "15.5.15",
         "next-auth": "^4.24.11",
         "next-themes": "^0.4.6",
-        "ogx-client": "^1.0.2",
+        "ogx-client": "^1.1.0",
         "papaparse": "^5.5.3",
         "react": "^19.0.0",
         "react-dom": "^19.2.0",
@@ -11178,9 +11178,9 @@
       }
     },
     "node_modules/ogx-client": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/ogx-client/-/ogx-client-1.0.2.tgz",
-      "integrity": "sha512-wlgUV/4ROjBP6yI2zc+kUwk1JpdV8M/D+D08sv3tJ4Y9c2qzGDmnqCvnNUXqfOBPEzxN/oRG3MgtSzdrEb4jFQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/ogx-client/-/ogx-client-1.1.0.tgz",
+      "integrity": "sha512-qRfpWms8Bbq8eKr25IibX1r0GTp28vmpmIr5y1ELyQ0QAIAdHB87V3PsDMi/Ub4FWmmaaCPp6bV+shwZp1m40A==",
       "license": "MIT",
       "dependencies": {
         "@types/node": "^18.11.18",

--- a/src/ogx_ui/package.json
+++ b/src/ogx_ui/package.json
@@ -50,7 +50,7 @@
     "next": "15.5.15",
     "next-auth": "^4.24.11",
     "next-themes": "^0.4.6",
-    "ogx-client": "^1.0.2",
+    "ogx-client": "^1.1.0",
     "papaparse": "^5.5.3",
     "react": "^19.0.0",
     "react-dom": "^19.2.0",

--- a/tests/integration/vector_io/test_openai_vector_stores.py
+++ b/tests/integration/vector_io/test_openai_vector_stores.py
@@ -3585,7 +3585,7 @@ def test_openai_vector_store_with_chunks(
     filtered_search = compat_client.vector_stores.search(
         vector_store_id=vector_store.id,
         query="artificial intelligence",
-        filters={"topic": "ai"},
+        filters={"type": "eq", "key": "topic", "value": "ai"},
         max_num_results=5,
     )
 

--- a/tests/unit/providers/vector_io/test_vector_io_stores_config.py
+++ b/tests/unit/providers/vector_io/test_vector_io_stores_config.py
@@ -213,6 +213,32 @@ async def test_search_vector_store_ignores_rewrite_query(vector_io_adapter):
     assert result.search_query == ["test query"]  # Original query preserved
 
 
+async def test_search_vector_store_propagates_backend_errors(vector_io_adapter):
+    """Test that exceptions from the vector store backend propagate to the caller."""
+    vector_store_id = "test_store_error"
+    vector_io_adapter.openai_vector_stores[vector_store_id] = {
+        "id": vector_store_id,
+        "name": "Test Store",
+        "description": "",
+        "vector_store_id": "test_db",
+        "embedding_model": "test/embedding",
+    }
+
+    async def mock_query_chunks(*args, **kwargs):
+        raise KeyError("chunk_content")
+
+    vector_io_adapter.query_chunks = mock_query_chunks
+
+    from ogx_api import OpenAISearchVectorStoreRequest
+
+    request = OpenAISearchVectorStoreRequest(query="test query", max_num_results=5)
+    with pytest.raises(KeyError, match="chunk_content"):
+        await vector_io_adapter.openai_search_vector_store(
+            vector_store_id=vector_store_id,
+            request=request,
+        )
+
+
 async def test_create_gin_index_executes_correct_sql():
     from ogx.providers.remote.vector_io.pgvector.config import PGVectorHNSWVectorIndex
     from ogx.providers.remote.vector_io.pgvector.pgvector import PGVectorIndex

--- a/uv.lock
+++ b/uv.lock
@@ -3981,6 +3981,7 @@ wheels = [
 
 [[package]]
 name = "ogx"
+version = "1.1.1+rhaiv.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },
@@ -4256,7 +4257,7 @@ requires-dist = [
     { name = "nltk", marker = "extra == 'starter'", specifier = ">=3.9.4" },
     { name = "numpy", marker = "extra == 'starter'" },
     { name = "ogx-api", editable = "src/ogx_api" },
-    { name = "ogx-client", marker = "extra == 'client'", specifier = "==1.1.0" },
+    { name = "ogx-client", marker = "extra == 'client'", specifier = "==1.1.1" },
     { name = "ollama", marker = "extra == 'starter'" },
     { name = "openai", specifier = ">=2.41.0" },
     { name = "opentelemetry-distro", specifier = ">=0.60b1" },
@@ -4324,7 +4325,7 @@ dev = [
     { name = "moto", extras = ["s3"], specifier = ">=5.1.10" },
     { name = "mypy" },
     { name = "nbval" },
-    { name = "ogx-client", specifier = "==1.1.0" },
+    { name = "ogx-client", specifier = "==1.1.1" },
     { name = "ollama" },
     { name = "openapi-spec-validator", specifier = ">=0.9.0" },
     { name = "pgvector", specifier = ">=0.3.0" },
@@ -4417,7 +4418,7 @@ type-checking = [
     { name = "markitdown", extras = ["all"] },
     { name = "mcp", specifier = ">=1.23.0,<2.0" },
     { name = "nest-asyncio" },
-    { name = "ogx-client", specifier = "==1.1.0" },
+    { name = "ogx-client", specifier = "==1.1.1" },
     { name = "ollama" },
     { name = "pandas" },
     { name = "pandas-stubs" },
@@ -4461,6 +4462,7 @@ unit = [
 
 [[package]]
 name = "ogx-api"
+version = "1.1.1+rhaiv.0"
 source = { editable = "src/ogx_api" }
 dependencies = [
     { name = "fastapi" },
@@ -4485,7 +4487,7 @@ requires-dist = [
 
 [[package]]
 name = "ogx-client"
-version = "1.1.0"
+version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -4504,9 +4506,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/16/df/34b1895ca3d608434347db103c3711b158feea3db9f091366ac93ee126cf/ogx_client-1.1.0.tar.gz", hash = "sha256:b51d945544a59212e960b692ee2832f7c59c683f997f33d9f7ea55ef63de68e4", size = 440837, upload-time = "2026-06-11T13:10:30.331Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3d/c4/11070a6b3c0712e5821bd5248a08fcf39c9e4c342fbf3377f0b04f6ad49e/ogx_client-1.1.1.tar.gz", hash = "sha256:6157cb5d4e25cf1555b6ed686994e6e3169b8d75b0d9beb517e7b16953591ed7", size = 440837, upload-time = "2026-06-15T15:17:43.874Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3b/d3/19cd05d73b8c4ac6402fe73d74fdcd30a6072889a4a2a4f476957c333aa9/ogx_client-1.1.0-py3-none-any.whl", hash = "sha256:fd09360e39dd0ff142f7a9cde417318c25e3b68ce44f0e061d1de4fd24e2bce8", size = 314014, upload-time = "2026-06-11T13:10:28.843Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/f0/00386a5490d34996cd11a27f593024de53fef70c58a40384aaaed356406b/ogx_client-1.1.1-py3-none-any.whl", hash = "sha256:1449edb824818b470ec84bf114d66942689d109d2e1fe6bff7ed03b91717f120", size = 314009, upload-time = "2026-06-15T15:17:42.226Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -4256,7 +4256,7 @@ requires-dist = [
     { name = "nltk", marker = "extra == 'starter'", specifier = ">=3.9.4" },
     { name = "numpy", marker = "extra == 'starter'" },
     { name = "ogx-api", editable = "src/ogx_api" },
-    { name = "ogx-client", marker = "extra == 'client'", specifier = ">=1.0.2" },
+    { name = "ogx-client", marker = "extra == 'client'", specifier = "==1.1.0" },
     { name = "ollama", marker = "extra == 'starter'" },
     { name = "openai", specifier = ">=2.41.0" },
     { name = "opentelemetry-distro", specifier = ">=0.60b1" },
@@ -4324,7 +4324,7 @@ dev = [
     { name = "moto", extras = ["s3"], specifier = ">=5.1.10" },
     { name = "mypy" },
     { name = "nbval" },
-    { name = "ogx-client", specifier = ">=1.0.2" },
+    { name = "ogx-client", specifier = "==1.1.0" },
     { name = "ollama" },
     { name = "openapi-spec-validator", specifier = ">=0.9.0" },
     { name = "pgvector", specifier = ">=0.3.0" },
@@ -4417,7 +4417,7 @@ type-checking = [
     { name = "markitdown", extras = ["all"] },
     { name = "mcp", specifier = ">=1.23.0,<2.0" },
     { name = "nest-asyncio" },
-    { name = "ogx-client", specifier = ">=1.0.2" },
+    { name = "ogx-client", specifier = "==1.1.0" },
     { name = "ollama" },
     { name = "pandas" },
     { name = "pandas-stubs" },
@@ -4485,7 +4485,7 @@ requires-dist = [
 
 [[package]]
 name = "ogx-client"
-version = "1.0.2"
+version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -4504,9 +4504,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/91/74/3edc7a8f396137741d9b29a728bcf45afd4a8266b40f1080ec0118c52065/ogx_client-1.0.2.tar.gz", hash = "sha256:4f5d0a5285fdbfcd3c260c291d70d325cf44b743a67c51e65d8a0c5f5cd76177", size = 435217, upload-time = "2026-05-13T22:52:04.778Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/16/df/34b1895ca3d608434347db103c3711b158feea3db9f091366ac93ee126cf/ogx_client-1.1.0.tar.gz", hash = "sha256:b51d945544a59212e960b692ee2832f7c59c683f997f33d9f7ea55ef63de68e4", size = 440837, upload-time = "2026-06-11T13:10:30.331Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b0/fc/4bf0216fd6e13943837f30164937d6db78dd8743424984ce22c763491c22/ogx_client-1.0.2-py3-none-any.whl", hash = "sha256:167ad9f36ec632cd579bb6451dc8137d90d755d78cd7073d8fc9dcc9bf622fa5", size = 309278, upload-time = "2026-05-13T22:52:03.149Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/d3/19cd05d73b8c4ac6402fe73d74fdcd30a6072889a4a2a4f476957c333aa9/ogx_client-1.1.0-py3-none-any.whl", hash = "sha256:fd09360e39dd0ff142f7a9cde417318c25e3b68ce44f0e061d1de4fd24e2bce8", size = 314014, upload-time = "2026-06-11T13:10:28.843Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Merge upstream tag v1.1.1 into release-3.5-ea.2
- Bump version to 1.1.1+rhaiv.0

The automated workflow failed because branch protection on release-3.5-ea.2
requires changes through a pull request.

Upstream changes in v1.1.1:
- VertexAI provider improvements
- File processor fixes (docling, markitdown, pypdf)
- Qdrant vector store fixes
- Milvus vector store fix
- Server startup improvements