### PR TITLE
fix: bump pillow>=12.2.0 for CVE-2026-40192

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
     "rich",
     "termcolor",
     "tiktoken",
-    "pillow",
+    "pillow>=12.2.0",
     "h11>=0.16.0",
     "python-multipart>=0.0.20",                       # For fastapi Form
     "uvicorn>=0.34.0",                                # server

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ constraint-dependencies = [
 
 [project]
 name = "llama_stack"
-version = "0.4.2.2+rhai0"
+version = "0.4.2.3+rhai0"
 authors = [{ name = "Meta Llama", email = "llama-oss@meta.com" }]
 description = "Llama Stack"
 readme = "README.md"

--- a/src/llama_stack/providers/registry/agents.py
+++ b/src/llama_stack/providers/registry/agents.py
@@ -21,7 +21,7 @@ def available_providers() -> list[ProviderSpec]:
             pip_packages=[
                 "matplotlib",
                 "fonttools>=4.60.2",
-                "pillow",
+                "pillow>=12.2.0",
                 "pandas",
                 "scikit-learn",
                 "mcp>=1.23.0",


### PR DESCRIPTION
Bump pillow>=12.2.0 for CVE-2026-40192 (Pillow DoS via decompression bomb in FITS image processing).

Version bumped to `0.4.2.3+rhai0`.