### PR TITLE
fix: bump pillow>=12.2.0 for CVE-2026-40192

### DIFF
--- a/llama_stack/providers/registry/agents.py
+++ b/llama_stack/providers/registry/agents.py
@@ -20,7 +20,7 @@ def available_providers() -> list[ProviderSpec]:
             provider_type="inline::meta-reference",
             pip_packages=[
                 "matplotlib",
-                "pillow",
+                "pillow>=12.2.0",
                 "pandas",
                 "scikit-learn",
                 "mcp>=1.8.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ required-version = ">=0.7.0"
 
 [project]
 name = "llama_stack"
-version = "0.2.22.3+rhai0"
+version = "0.2.22.4+rhai0"
 authors = [{ name = "Meta Llama", email = "llama-oss@meta.com" }]
 description = "Llama Stack"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
     "starlette>=1.0.1",
     "termcolor",
     "tiktoken",
-    "pillow",
+    "pillow>=12.2.0",
     "h11>=0.16.0",
     "python-multipart>=0.0.20",               # For fastapi Form
     "uvicorn>=0.34.0",                        # server


### PR DESCRIPTION
Bump pillow>=12.2.0 for CVE-2026-40192 (Pillow DoS via decompression bomb in FITS image processing).

Version bumped to `0.2.22.4+rhai0`.