### PR TITLE
chore: merge upstream v1.1.2 into release-3.5-ea.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=61.0", "setuptools-scm>=8.0"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]
-fallback_version = "1.1.1"
+fallback_version = "1.1.2"
 
 [tool.uv]
 required-version = ">=0.7.0"
@@ -80,7 +80,7 @@ dependencies = [
 
 [project.optional-dependencies]
 client = [
-    "ogx-client==1.1.1", # Optional for library-only usage
+    "ogx-client==1.1.2", # Optional for library-only usage
 ]
 starter = [
     "aiohttp",
@@ -144,7 +144,7 @@ dev = [
     "pre-commit>=4.4.0",
     "ruamel.yaml",                   # needed for openapi generator
     "openapi-spec-validator>=0.9.0",
-    "ogx-client==1.1.1",
+    "ogx-client==1.1.2",
     "boto3>=1.43.18",
     "torch>=2.6.0",
 ]
@@ -183,7 +183,7 @@ type_checking = [
     "langchain-openai>=1.2.2",
     "langchain-core",
     "langgraph",
-    "ogx-client==1.1.1",
+    "ogx-client==1.1.2",
 ]
 test-common = [
     "aiohttp",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ constraint-dependencies = [
 
 [project]
 name = "ogx"
-version = "1.1.1+rhaiv.0"
+version = "1.1.2+rhaiv.0"
 authors = [{ name = "The OGX Contributors", email = "contributors@ogx.dev" }]
 description = "Open-source, OpenAI-compatible API server with pluggable providers for any model and any infrastructure"
 readme = "README.md"

--- a/src/ogx/core/conversations/conversations.py
+++ b/src/ogx/core/conversations/conversations.py
@@ -37,7 +37,7 @@ from ogx_api.conversations import (
     RetrieveItemRequest,
     UpdateConversationRequest,
 )
-from ogx_api.internal.sqlstore import ColumnDefinition, ColumnType
+from ogx_api.internal.sqlstore import ColumnDefinition, ColumnType, DeleteOperation
 
 logger = get_logger(name=__name__, category="openai_conversations")
 
@@ -182,7 +182,18 @@ class ConversationServiceImpl(Conversations):
         if record is None:
             raise ConversationNotFoundError(request.conversation_id)
 
-        await self.sql_store.delete(table="openai_conversations", where={"id": request.conversation_id})
+        await self.sql_store.delete_many(
+            [
+                DeleteOperation(
+                    table="conversation_items",
+                    where={"conversation_id": request.conversation_id},
+                ),
+                DeleteOperation(
+                    table="openai_conversations",
+                    where={"id": request.conversation_id},
+                ),
+            ]
+        )
 
         logger.debug("Deleted conversation", conversation_id=request.conversation_id)
         return ConversationDeletedResource(id=request.conversation_id)
@@ -273,6 +284,8 @@ class ConversationServiceImpl(Conversations):
         if not request.item_id:
             raise InvalidParameterError("item_id", request.item_id, "Must be a non-empty string.")
 
+        await self._get_validated_conversation(request.conversation_id)
+
         # Get item from conversation_items table
         record = await self.sql_store.fetch_one(
             table="conversation_items", where={"id": request.item_id, "conversation_id": request.conversation_id}
@@ -286,7 +299,7 @@ class ConversationServiceImpl(Conversations):
 
     async def list_items(self, request: ListItemsRequest) -> ConversationItemList:
         """List items in the conversation with cursor pagination."""
-        await self.get_conversation(GetConversationRequest(conversation_id=request.conversation_id))
+        await self._get_validated_conversation(request.conversation_id)
 
         order = request.order if request.order is not None else "desc"
         limit = request.limit or 20

--- a/src/ogx/core/storage/sqlstore/authorized_sqlstore.py
+++ b/src/ogx/core/storage/sqlstore/authorized_sqlstore.py
@@ -25,7 +25,7 @@ from ogx.core.storage.datatypes import SqlStoreReference, StorageBackendType
 from ogx.core.storage.sqlstore.sqlstore import _sqlstore_impl
 from ogx.log import get_logger
 from ogx_api import PaginatedResponse
-from ogx_api.internal.sqlstore import ColumnDefinition, ColumnType, SqlStore
+from ogx_api.internal.sqlstore import ColumnDefinition, ColumnType, DeleteOperation, SqlStore
 
 logger = get_logger(name=__name__, category="providers::utils")
 
@@ -330,6 +330,33 @@ class AuthorizedSqlStore:
             return
 
         await self.sql_store.delete(table, where)
+
+    async def delete_many(self, operations: Sequence[DeleteOperation]) -> None:
+        """Delete multiple row sets atomically with access control enforcement."""
+        if not operations:
+            return
+
+        current_user = get_authenticated_user()
+        for operation in operations:
+            await self._check_access_for_rows(operation.table, operation.where, Action.DELETE, current_user)
+
+        if self._can_apply_sql_policy_filter_for_mutations(current_user):
+            access_where, access_params = self._build_access_control_where_clause(self.policy)
+            filtered_operations = [
+                DeleteOperation(
+                    table=operation.table,
+                    where=operation.where,
+                    where_sql=(
+                        access_where if operation.where_sql is None else f"({operation.where_sql}) AND ({access_where})"
+                    ),
+                    where_sql_params={**(operation.where_sql_params or {}), **access_params},
+                )
+                for operation in operations
+            ]
+            await self.sql_store.delete_many(filtered_operations)
+            return
+
+        await self.sql_store.delete_many(operations)
 
     async def _check_access_for_rows(
         self,

--- a/src/ogx/core/storage/sqlstore/sqlalchemy_sqlstore.py
+++ b/src/ogx/core/storage/sqlstore/sqlalchemy_sqlstore.py
@@ -32,7 +32,7 @@ from sqlalchemy.sql.elements import ColumnElement
 from ogx.core.storage.datatypes import PostgresSqlStoreConfig, SqlAlchemySqlStoreConfig, SqliteSqlStoreConfig
 from ogx.log import get_logger
 from ogx_api import PaginatedResponse
-from ogx_api.internal.sqlstore import ColumnDefinition, ColumnType, SqlStore
+from ogx_api.internal.sqlstore import ColumnDefinition, ColumnType, DeleteOperation, SqlStore
 
 logger = get_logger(name=__name__, category="providers::utils")
 
@@ -379,6 +379,26 @@ class SqlAlchemySqlStoreImpl(SqlStore):
             await session.execute(stmt, data)
             await session.commit()
 
+    def _build_delete_statement(
+        self,
+        table: str,
+        where: Mapping[str, Any],
+        where_sql: str | None = None,
+        where_sql_params: Mapping[str, Any] | None = None,
+    ) -> tuple[Any, Mapping[str, Any] | None]:
+        if not where:
+            raise ValueError("where is required for delete")
+
+        stmt = self.metadata.tables[table].delete()
+        for key, value in where.items():
+            stmt = stmt.where(_build_where_expr(self.metadata.tables[table].c[key], value))
+        if where_sql:
+            clause = text(where_sql)
+            if where_sql_params:
+                clause = clause.bindparams(**where_sql_params)
+            stmt = stmt.where(clause)
+        return stmt, where_sql_params
+
     async def delete(
         self,
         table: str,
@@ -388,20 +408,27 @@ class SqlAlchemySqlStoreImpl(SqlStore):
     ) -> None:
         await self._ensure_engine()  # Lazy init in current event loop
         assert self.async_session is not None  # _ensure_engine guarantees this
-        if not where:
-            raise ValueError("where is required for delete")
+        async with self.async_session() as session:
+            stmt, params = self._build_delete_statement(table, where, where_sql, where_sql_params)
+            await session.execute(stmt, params)
+            await session.commit()
+
+    async def delete_many(self, operations: Sequence[DeleteOperation]) -> None:
+        await self._ensure_engine()  # Lazy init in current event loop
+        assert self.async_session is not None  # _ensure_engine guarantees this
+        if not operations:
+            return
 
         async with self.async_session() as session:
-            stmt = self.metadata.tables[table].delete()
-            for key, value in where.items():
-                stmt = stmt.where(_build_where_expr(self.metadata.tables[table].c[key], value))
-            if where_sql:
-                clause = text(where_sql)
-                if where_sql_params:
-                    clause = clause.bindparams(**where_sql_params)
-                stmt = stmt.where(clause)
-            await session.execute(stmt)
-            await session.commit()
+            async with session.begin():
+                for operation in operations:
+                    stmt, params = self._build_delete_statement(
+                        operation.table,
+                        operation.where,
+                        operation.where_sql,
+                        operation.where_sql_params,
+                    )
+                    await session.execute(stmt, params)
 
     async def add_column_if_not_exists(
         self,

--- a/src/ogx/providers/inline/file_processor/docling/docling.py
+++ b/src/ogx/providers/inline/file_processor/docling/docling.py
@@ -20,6 +20,7 @@ from docling_core.transforms.chunker.tokenizer.huggingface import HuggingFaceTok
 from fastapi import UploadFile
 
 from ogx.log import get_logger
+from ogx.providers.inline.file_processor.zip_utils import validate_zip_content
 from ogx.providers.utils.vector_io.vector_utils import generate_chunk_id
 from ogx_api.file_processors import ProcessFileRequest, ProcessFileResponse
 from ogx_api.files import RetrieveFileContentRequest, RetrieveFileRequest
@@ -94,6 +95,8 @@ class DoclingFileProcessor:
         start_time: float,
     ) -> ProcessFileResponse:
         """Convert and chunk file content. Runs in a thread."""
+        validate_zip_content(content, filename)
+
         # Preserve original file extension so DocumentConverter can detect the format
         suffix = os.path.splitext(filename)[1] or ".bin"
         with tempfile.NamedTemporaryFile(suffix=suffix, delete=True) as tmp:

--- a/src/ogx/providers/inline/file_processor/markitdown/markitdown_processor.py
+++ b/src/ogx/providers/inline/file_processor/markitdown/markitdown_processor.py
@@ -16,6 +16,7 @@ from fastapi import HTTPException, UploadFile
 from markitdown import MarkItDown
 
 from ogx.log import get_logger
+from ogx.providers.inline.file_processor.zip_utils import validate_zip_content
 from ogx.providers.utils.memory.vector_store import make_overlapped_chunks
 from ogx_api.file_processors import ProcessFileRequest, ProcessFileResponse
 from ogx_api.files import RetrieveFileContentRequest, RetrieveFileRequest
@@ -83,6 +84,8 @@ class MarkItDownFileProcessor:
         start_time: float,
     ) -> ProcessFileResponse:
         """Convert and chunk file content. Runs in a thread."""
+        validate_zip_content(content, filename)
+
         suffix = os.path.splitext(filename)[1] or ".bin"
         with tempfile.NamedTemporaryFile(suffix=suffix, delete=True) as tmp:
             tmp.write(content)

--- a/src/ogx/providers/inline/file_processor/zip_utils.py
+++ b/src/ogx/providers/inline/file_processor/zip_utils.py
@@ -1,0 +1,42 @@
+# Copyright (c) The OGX Contributors.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+import io
+import zipfile
+
+from fastapi import HTTPException
+
+MAX_ZIP_DECOMPRESSED_BYTES = 25 * 1024 * 1024  # 25MiB
+MAX_ZIP_ENTRIES = 1000
+
+
+def validate_zip_content(content: bytes, filename: str) -> None:
+    """Reject ZIP archives that exceed decompression limits.
+
+    Call before processing any file that may be ZIP-based (DOCX, PPTX, XLSX, etc.).
+    """
+    if not zipfile.is_zipfile(io.BytesIO(content)):
+        return
+
+    with zipfile.ZipFile(io.BytesIO(content), "r") as zf:
+        entries = zf.infolist()
+        if len(entries) > MAX_ZIP_ENTRIES:
+            raise HTTPException(
+                status_code=422,
+                detail=(
+                    f"Failed to process file '{filename}': ZIP contains {len(entries)} entries, "
+                    f"exceeding the limit of {MAX_ZIP_ENTRIES}"
+                ),
+            )
+        total_size = sum(e.file_size for e in entries)
+        if total_size > MAX_ZIP_DECOMPRESSED_BYTES:
+            raise HTTPException(
+                status_code=422,
+                detail=(
+                    f"Failed to process file '{filename}': ZIP decompressed size "
+                    f"({total_size} bytes) exceeds the limit of {MAX_ZIP_DECOMPRESSED_BYTES} bytes"
+                ),
+            )

--- a/src/ogx_api/internal/sqlstore.py
+++ b/src/ogx_api/internal/sqlstore.py
@@ -5,6 +5,7 @@
 # the root directory of this source tree.
 
 from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Literal, Protocol
 
@@ -32,6 +33,16 @@ class ColumnDefinition(BaseModel):
     primary_key: bool = False
     nullable: bool = True
     default: Any = None
+
+
+@dataclass(frozen=True)
+class DeleteOperation:
+    """A single SQL delete operation."""
+
+    table: str
+    where: Mapping[str, Any]
+    where_sql: str | None = None
+    where_sql_params: Mapping[str, Any] | None = None
 
 
 class SqlStore(Protocol):
@@ -86,6 +97,8 @@ class SqlStore(Protocol):
         where_sql_params: Mapping[str, Any] | None = None,
     ) -> None: ...
 
+    async def delete_many(self, operations: Sequence[DeleteOperation]) -> None: ...
+
     async def add_column_if_not_exists(
         self,
         table: str,
@@ -97,4 +110,4 @@ class SqlStore(Protocol):
     async def shutdown(self) -> None: ...
 
 
-__all__ = ["ColumnDefinition", "ColumnType", "SqlStore"]
+__all__ = ["ColumnDefinition", "ColumnType", "DeleteOperation", "SqlStore"]

--- a/src/ogx_api/pyproject.toml
+++ b/src/ogx_api/pyproject.toml
@@ -96,7 +96,7 @@ ogx_api = ["py.typed", "**/*.json", "**/*.yaml"]
 
 [tool.setuptools_scm]
 root = "../.."
-fallback_version = "1.1.1"
+fallback_version = "1.1.2"
 
 [tool.ruff]
 line-length = 120

--- a/src/ogx_api/pyproject.toml
+++ b/src/ogx_api/pyproject.toml
@@ -14,7 +14,7 @@ constraint-dependencies = [
 
 [project]
 name = "ogx-api"
-version = "1.1.1+rhaiv.0"
+version = "1.1.2+rhaiv.0"
 authors = [{ name = "The OGX Contributors", email = "contributors@ogx.dev" }]
 description = "API and Provider specifications for OGX - lightweight package with protocol definitions and provider specs"
 readme = "README.md"

--- a/src/ogx_ui/package-lock.json
+++ b/src/ogx_ui/package-lock.json
@@ -26,7 +26,7 @@
         "next": "15.5.15",
         "next-auth": "^4.24.11",
         "next-themes": "^0.4.6",
-        "ogx-client": "^1.1.0",
+        "ogx-client": "^1.1.1",
         "papaparse": "^5.5.3",
         "react": "^19.0.0",
         "react-dom": "^19.2.0",
@@ -11178,9 +11178,9 @@
       }
     },
     "node_modules/ogx-client": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/ogx-client/-/ogx-client-1.1.0.tgz",
-      "integrity": "sha512-qRfpWms8Bbq8eKr25IibX1r0GTp28vmpmIr5y1ELyQ0QAIAdHB87V3PsDMi/Ub4FWmmaaCPp6bV+shwZp1m40A==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ogx-client/-/ogx-client-1.1.1.tgz",
+      "integrity": "sha512-ZJSvUBEW4P7PqIyESI700pUO81aLoOSB2jAhsI30JFpOxvC9/ii1EFgn5kJ9XIVJ+gR7UOvkYhxF/tgF3Ky3NQ==",
       "license": "MIT",
       "dependencies": {
         "@types/node": "^18.11.18",

--- a/src/ogx_ui/package.json
+++ b/src/ogx_ui/package.json
@@ -50,7 +50,7 @@
     "next": "15.5.15",
     "next-auth": "^4.24.11",
     "next-themes": "^0.4.6",
-    "ogx-client": "^1.1.0",
+    "ogx-client": "^1.1.1",
     "papaparse": "^5.5.3",
     "react": "^19.0.0",
     "react-dom": "^19.2.0",

--- a/tests/integration/conversations/test_openai_conversations.py
+++ b/tests/integration/conversations/test_openai_conversations.py
@@ -7,7 +7,7 @@
 import os
 
 import pytest
-from openai import OpenAI
+from openai import NotFoundError, OpenAI
 
 
 def get_auth_token(env_var: str, default: str) -> str:
@@ -55,6 +55,25 @@ class TestOpenAIConversations:
         assert deleted.id == conversation.id
         assert deleted.object == "conversation.deleted"
         assert deleted.deleted is True
+
+    def test_deleted_conversation_items_are_not_accessible(self, openai_client):
+        conversation = openai_client.conversations.create()
+
+        created_items = openai_client.conversations.items.create(
+            conversation.id,
+            items=[{"type": "message", "role": "user", "content": [{"type": "input_text", "text": "Hello!"}]}],
+        )
+        item_id = created_items.data[0].id
+
+        openai_client.conversations.delete(conversation.id)
+
+        with pytest.raises(NotFoundError) as exc_info:
+            openai_client.conversations.items.list(conversation.id)
+        assert exc_info.value.status_code == 404
+
+        with pytest.raises(NotFoundError) as exc_info:
+            openai_client.conversations.items.retrieve(item_id, conversation_id=conversation.id)
+        assert exc_info.value.status_code == 404
 
     def test_conversation_items_create(self, openai_client):
         conversation = openai_client.conversations.create()

--- a/tests/unit/conversations/test_conversations.py
+++ b/tests/unit/conversations/test_conversations.py
@@ -18,6 +18,7 @@ import pytest
 from openai.types.conversations.conversation import Conversation as OpenAIConversation
 from openai.types.conversations.conversation_item import ConversationItem as OpenAIConversationItem
 from pydantic import TypeAdapter
+from sqlalchemy import event
 
 from ogx.core.conversations.conversations import (
     ConversationServiceConfig,
@@ -91,6 +92,85 @@ async def test_conversation_lifecycle(service):
 
     deleted = await service.openai_delete_conversation(DeleteConversationRequest(conversation_id=conversation.id))
     assert deleted.id == conversation.id
+
+
+async def test_delete_conversation_cascades_to_items(service):
+    """Deleting a conversation must remove its items and block further item access."""
+    conversation = await service.create_conversation(CreateConversationRequest())
+    items = [
+        OpenAIResponseMessage(
+            type="message",
+            role="user",
+            content=[OpenAIResponseInputMessageContentText(type="input_text", text="Hello")],
+            id="msg_deletecascade123",
+            status="completed",
+        )
+    ]
+    await service.add_items(conversation.id, AddItemsRequest(items=items))
+
+    listed = await service.list_items(ListItemsRequest(conversation_id=conversation.id))
+    assert len(listed.data) == 1
+    item_id = listed.data[0].id
+
+    await service.openai_delete_conversation(DeleteConversationRequest(conversation_id=conversation.id))
+
+    with pytest.raises(ConversationNotFoundError):
+        await service.list_items(ListItemsRequest(conversation_id=conversation.id))
+
+    with pytest.raises(ConversationNotFoundError):
+        await service.retrieve(RetrieveItemRequest(conversation_id=conversation.id, item_id=item_id))
+
+    raw_items = await service.sql_store.fetch_all(
+        table="conversation_items", where={"conversation_id": conversation.id}
+    )
+    assert raw_items.data == []
+
+
+async def test_delete_conversation_is_atomic_when_parent_delete_fails(service):
+    """A failed parent delete must roll back the child-row delete in the same operation."""
+    conversation = await service.create_conversation(CreateConversationRequest())
+    items = [
+        OpenAIResponseMessage(
+            type="message",
+            role="user",
+            content=[OpenAIResponseInputMessageContentText(type="input_text", text="Hello")],
+            id="msg_atomicdelete123",
+            status="completed",
+        )
+    ]
+    await service.add_items(conversation.id, AddItemsRequest(items=items))
+
+    listed_before_delete = await service.list_items(ListItemsRequest(conversation_id=conversation.id))
+    assert len(listed_before_delete.data) == 1
+
+    sql_store_impl = service.sql_store.sql_store
+    await sql_store_impl._ensure_engine()
+    assert sql_store_impl._engine is not None
+
+    failure_triggered = {"value": False}
+
+    def fail_parent_delete(
+        conn, cursor, statement, parameters, context, executemany
+    ):  # pragma: no cover - SQLAlchemy callback signature
+        if statement.startswith("DELETE FROM openai_conversations"):
+            failure_triggered["value"] = True
+            raise RuntimeError("Injected parent delete failure")
+
+    event.listen(sql_store_impl._engine.sync_engine, "before_cursor_execute", fail_parent_delete)
+    try:
+        with pytest.raises(RuntimeError, match="Injected parent delete failure"):
+            await service.openai_delete_conversation(DeleteConversationRequest(conversation_id=conversation.id))
+    finally:
+        event.remove(sql_store_impl._engine.sync_engine, "before_cursor_execute", fail_parent_delete)
+
+    assert failure_triggered["value"] is True
+
+    conversation_after_failure = await service.get_conversation(GetConversationRequest(conversation_id=conversation.id))
+    assert conversation_after_failure.id == conversation.id
+
+    listed_after_failure = await service.list_items(ListItemsRequest(conversation_id=conversation.id))
+    assert len(listed_after_failure.data) == 1
+    assert listed_after_failure.data[0].id == "msg_atomicdelete123"
 
 
 async def test_conversation_items(service):

--- a/tests/unit/providers/file_processor/test_zip_validation.py
+++ b/tests/unit/providers/file_processor/test_zip_validation.py
@@ -1,0 +1,92 @@
+# Copyright (c) The OGX Contributors.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+import io
+import zipfile
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import HTTPException, UploadFile
+
+from ogx.providers.inline.file_processor.markitdown.config import MarkItDownFileProcessorConfig
+from ogx.providers.inline.file_processor.markitdown.markitdown_processor import MarkItDownFileProcessor
+from ogx.providers.inline.file_processor.zip_utils import (
+    MAX_ZIP_DECOMPRESSED_BYTES,
+    MAX_ZIP_ENTRIES,
+    validate_zip_content,
+)
+
+
+def _make_zip(num_entries: int, per_entry_bytes: int) -> bytes:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        for i in range(num_entries):
+            zf.writestr(f"file_{i}.txt", "A" * per_entry_bytes)
+    return buf.getvalue()
+
+
+# --- Unit tests for validate_zip_content ---
+
+
+def test_validate_zip_rejects_too_many_entries():
+    zip_bytes = _make_zip(MAX_ZIP_ENTRIES + 1, 1)
+    with pytest.raises(HTTPException) as exc_info:
+        validate_zip_content(zip_bytes, "bomb.zip")
+    assert exc_info.value.status_code == 422
+    assert "entries" in exc_info.value.detail.lower()
+
+
+def test_validate_zip_rejects_oversized():
+    per_entry = MAX_ZIP_DECOMPRESSED_BYTES // 2 + 1
+    zip_bytes = _make_zip(2, per_entry)
+    with pytest.raises(HTTPException) as exc_info:
+        validate_zip_content(zip_bytes, "bomb.zip")
+    assert exc_info.value.status_code == 422
+    assert "decompressed size" in exc_info.value.detail.lower()
+
+
+def test_validate_zip_accepts_small_zip():
+    zip_bytes = _make_zip(2, 100)
+    validate_zip_content(zip_bytes, "small.zip")
+
+
+def test_validate_zip_ignores_non_zip():
+    validate_zip_content(b"just plain text", "readme.txt")
+
+
+# --- Integration: markitdown processor calls validation ---
+
+
+@pytest.fixture
+def markitdown_processor():
+    config = MarkItDownFileProcessorConfig()
+    files_api = MagicMock()
+    return MarkItDownFileProcessor(config, files_api)
+
+
+async def test_markitdown_rejects_zip_exceeding_entry_limit(markitdown_processor):
+    zip_bytes = _make_zip(MAX_ZIP_ENTRIES + 1, 1)
+    file = UploadFile(filename="bomb.zip", file=io.BytesIO(zip_bytes))
+
+    with pytest.raises(HTTPException) as exc_info:
+        await markitdown_processor.process_file(
+            request=MagicMock(file_id=None, chunking_strategy=None),
+            file=file,
+        )
+    assert exc_info.value.status_code == 422
+
+
+async def test_markitdown_rejects_zip_exceeding_size_limit(markitdown_processor):
+    per_entry = MAX_ZIP_DECOMPRESSED_BYTES // 2 + 1
+    zip_bytes = _make_zip(2, per_entry)
+    file = UploadFile(filename="bomb.zip", file=io.BytesIO(zip_bytes))
+
+    with pytest.raises(HTTPException) as exc_info:
+        await markitdown_processor.process_file(
+            request=MagicMock(file_id=None, chunking_strategy=None),
+            file=file,
+        )
+    assert exc_info.value.status_code == 422

--- a/uv.lock
+++ b/uv.lock
@@ -3981,7 +3981,7 @@ wheels = [
 
 [[package]]
 name = "ogx"
-version = "1.1.1+rhaiv.0"
+version = "1.1.2+rhaiv.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },
@@ -4257,7 +4257,7 @@ requires-dist = [
     { name = "nltk", marker = "extra == 'starter'", specifier = ">=3.9.4" },
     { name = "numpy", marker = "extra == 'starter'" },
     { name = "ogx-api", editable = "src/ogx_api" },
-    { name = "ogx-client", marker = "extra == 'client'", specifier = "==1.1.1" },
+    { name = "ogx-client", marker = "extra == 'client'", specifier = "==1.1.2" },
     { name = "ollama", marker = "extra == 'starter'" },
     { name = "openai", specifier = ">=2.41.0" },
     { name = "opentelemetry-distro", specifier = ">=0.60b1" },
@@ -4325,7 +4325,7 @@ dev = [
     { name = "moto", extras = ["s3"], specifier = ">=5.1.10" },
     { name = "mypy" },
     { name = "nbval" },
-    { name = "ogx-client", specifier = "==1.1.1" },
+    { name = "ogx-client", specifier = "==1.1.2" },
     { name = "ollama" },
     { name = "openapi-spec-validator", specifier = ">=0.9.0" },
     { name = "pgvector", specifier = ">=0.3.0" },
@@ -4418,7 +4418,7 @@ type-checking = [
     { name = "markitdown", extras = ["all"] },
     { name = "mcp", specifier = ">=1.23.0,<2.0" },
     { name = "nest-asyncio" },
-    { name = "ogx-client", specifier = "==1.1.1" },
+    { name = "ogx-client", specifier = "==1.1.2" },
     { name = "ollama" },
     { name = "pandas" },
     { name = "pandas-stubs" },
@@ -4462,7 +4462,7 @@ unit = [
 
 [[package]]
 name = "ogx-api"
-version = "1.1.1+rhaiv.0"
+version = "1.1.2+rhaiv.0"
 source = { editable = "src/ogx_api" }
 dependencies = [
     { name = "fastapi" },
@@ -4487,7 +4487,7 @@ requires-dist = [
 
 [[package]]
 name = "ogx-client"
-version = "1.1.1"
+version = "1.1.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -4506,9 +4506,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3d/c4/11070a6b3c0712e5821bd5248a08fcf39c9e4c342fbf3377f0b04f6ad49e/ogx_client-1.1.1.tar.gz", hash = "sha256:6157cb5d4e25cf1555b6ed686994e6e3169b8d75b0d9beb517e7b16953591ed7", size = 440837, upload-time = "2026-06-15T15:17:43.874Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/15/5f02de6eba355443a5687abfc8474beec4ac0aae3357629dc889547f62cb/ogx_client-1.1.2.tar.gz", hash = "sha256:2bb2e7d9100e6332d45dc003777027f9a2f7e9ec82d77cfa6c08ccb670172657", size = 440847, upload-time = "2026-06-17T14:11:44.312Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8e/f0/00386a5490d34996cd11a27f593024de53fef70c58a40384aaaed356406b/ogx_client-1.1.1-py3-none-any.whl", hash = "sha256:1449edb824818b470ec84bf114d66942689d109d2e1fe6bff7ed03b91717f120", size = 314009, upload-time = "2026-06-15T15:17:42.226Z" },
+    { url = "https://files.pythonhosted.org/packages/24/4f/c17e5520c0fc282b4b1654bdd5432c7c5e393ce1c5a5b305b34e5ce3ea14/ogx_client-1.1.2-py3-none-any.whl", hash = "sha256:c8b0a0657231da8151ed7267261d3dd7713482ef7d19d97adc13bb42ca25a5da", size = 314013, upload-time = "2026-06-17T14:11:42.51Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -4256,7 +4256,7 @@ requires-dist = [
     { name = "nltk", marker = "extra == 'starter'", specifier = ">=3.9.4" },
     { name = "numpy", marker = "extra == 'starter'" },
     { name = "ogx-api", editable = "src/ogx_api" },
-    { name = "ogx-client", marker = "extra == 'client'", specifier = "==1.1.0" },
+    { name = "ogx-client", marker = "extra == 'client'", specifier = "==1.1.1" },
     { name = "ollama", marker = "extra == 'starter'" },
     { name = "openai", specifier = ">=2.41.0" },
     { name = "opentelemetry-distro", specifier = ">=0.60b1" },
@@ -4324,7 +4324,7 @@ dev = [
     { name = "moto", extras = ["s3"], specifier = ">=5.1.10" },
     { name = "mypy" },
     { name = "nbval" },
-    { name = "ogx-client", specifier = "==1.1.0" },
+    { name = "ogx-client", specifier = "==1.1.1" },
     { name = "ollama" },
     { name = "openapi-spec-validator", specifier = ">=0.9.0" },
     { name = "pgvector", specifier = ">=0.3.0" },
@@ -4417,7 +4417,7 @@ type-checking = [
     { name = "markitdown", extras = ["all"] },
     { name = "mcp", specifier = ">=1.23.0,<2.0" },
     { name = "nest-asyncio" },
-    { name = "ogx-client", specifier = "==1.1.0" },
+    { name = "ogx-client", specifier = "==1.1.1" },
     { name = "ollama" },
     { name = "pandas" },
     { name = "pandas-stubs" },
@@ -4485,7 +4485,7 @@ requires-dist = [
 
 [[package]]
 name = "ogx-client"
-version = "1.1.0"
+version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -4504,9 +4504,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/16/df/34b1895ca3d608434347db103c3711b158feea3db9f091366ac93ee126cf/ogx_client-1.1.0.tar.gz", hash = "sha256:b51d945544a59212e960b692ee2832f7c59c683f997f33d9f7ea55ef63de68e4", size = 440837, upload-time = "2026-06-11T13:10:30.331Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3d/c4/11070a6b3c0712e5821bd5248a08fcf39c9e4c342fbf3377f0b04f6ad49e/ogx_client-1.1.1.tar.gz", hash = "sha256:6157cb5d4e25cf1555b6ed686994e6e3169b8d75b0d9beb517e7b16953591ed7", size = 440837, upload-time = "2026-06-15T15:17:43.874Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3b/d3/19cd05d73b8c4ac6402fe73d74fdcd30a6072889a4a2a4f476957c333aa9/ogx_client-1.1.0-py3-none-any.whl", hash = "sha256:fd09360e39dd0ff142f7a9cde417318c25e3b68ce44f0e061d1de4fd24e2bce8", size = 314014, upload-time = "2026-06-11T13:10:28.843Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/f0/00386a5490d34996cd11a27f593024de53fef70c58a40384aaaed356406b/ogx_client-1.1.1-py3-none-any.whl", hash = "sha256:1449edb824818b470ec84bf114d66942689d109d2e1fe6bff7ed03b91717f120", size = 314009, upload-time = "2026-06-15T15:17:42.226Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Merge upstream tag v1.1.2 into release-3.5-ea.2
- Bump version to 1.1.2+rhaiv.0

Upstream changes in v1.1.2:
- fix(sqlstore): harden SQL conversation and batch operations
- fix(file_processors): zip validation utilities
- fix(conversations): improved error handling
- fix(authorized_sqlstore): additional safety checks