### PR TITLE
fix: use PRs instead of direct pushes due to branch protections

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -21,6 +21,7 @@ OGX uses GitHub Actions for Continuous Integration (CI). Below is a table detail
 | Messages API - Claude Code Client Smoke Tests | [integration-tests-messages-clients.yml](integration-tests-messages-clients.yml) | Drive the Claude Code CLI and Agent SDK against /v1/messages (live, Ollama) |
 | Integration Tests (Replay) | [integration-tests.yml](integration-tests.yml) | Run the integration test suites from tests/integration in replay mode |
 | Vector IO Integration Tests | [integration-vector-io-tests.yml](integration-vector-io-tests.yml) | Run the integration test suite with various VectorIO providers |
+| Launch GPU EC2 Runner | [launch-gpu-ec2-runner.yml](launch-gpu-ec2-runner.yml) | Launch GPU EC2 Runner |
 | Create or Update Release Branch | [odh-create-or-update-release-branch.yml](odh-create-or-update-release-branch.yml) | Create or update release-${{ inputs.product_version }} from tag ${{ inputs.tag }} |
 | Create release tag | [odh-create-tag.yml](odh-create-tag.yml) | Create tag from version in pyproject.toml |
 | Dispatch Version Update to ODH Distribution | [odh-dispatch-version-update-to-odh-distribution.yml](odh-dispatch-version-update-to-odh-distribution.yml) | Dispatch version update to llama-stack-distribution (${{ github.ref_name }}) |
@@ -35,10 +36,11 @@ OGX uses GitHub Actions for Continuous Integration (CI). Below is a table detail
 | Integration Tests (Record) | [record-integration-tests.yml](record-integration-tests.yml) | Auto-record missing test recordings for PR |
 | Release Branch Scheduled CI | [release-branch-scheduled-ci.yml](release-branch-scheduled-ci.yml) | Scheduled CI checks for active release branches |
 | Check semantic PR titles | [semantic-pr.yml](semantic-pr.yml) | Ensure that PR titles follow the conventional commit spec |
-| Stainless SDK Builds | [stainless-builds.yml](stainless-builds.yml) | Build Stainless SDK from OpenAPI spec changes |
 | Close stale issues and PRs | [stale_bot.yml](stale_bot.yml) | Run the Stale Bot action |
 | Test External Providers Installed via Module | [test-external-provider-module.yml](test-external-provider-module.yml) | Test External Provider installation via Python module |
 | Test External API and Providers | [test-external.yml](test-external.yml) | Test the External API and Provider mechanisms |
 | Trigger Docs Deploy | [trigger-docs-deploy.yml](trigger-docs-deploy.yml) | Trigger docs site rebuild after docs change |
+| Trivy Scheduled Security Scan | [trivy-scheduled.yml](trivy-scheduled.yml) | Trivy Scheduled Security Scan |
+| Trivy Security Scan | [trivy-security.yml](trivy-security.yml) | Trivy Security Scan |
 | UI Tests | [ui-unit-tests.yml](ui-unit-tests.yml) | Run the UI test suite |
 | Unit Tests | [unit-tests.yml](unit-tests.yml) | Run the unit test suite |

--- a/.github/workflows/odh-create-or-update-release-branch.yml
+++ b/.github/workflows/odh-create-or-update-release-branch.yml
@@ -88,6 +88,13 @@ jobs:
           fi
           echo "Merged tag '${TAG}' into branch '${BRANCH}'"
 
+      - name: Create temporary branch for PR
+        if: steps.check-branch.outputs.exists == 'true'
+        run: |
+          TEMP_BRANCH="update-${BRANCH}-${TAG}"
+          git checkout -b "${TEMP_BRANCH}"
+          echo "Created temporary branch '${TEMP_BRANCH}' for PR"
+
       - name: Copy ODH workflows from main
         run: |
           workflows=(
@@ -156,7 +163,22 @@ jobs:
             git commit -m "chore: set version to ${PROJECT_VERSION} for ${BRANCH}"
           fi
 
-      - name: Push release branch
+      - name: Push new release branch
+        if: steps.check-branch.outputs.exists == 'false'
         run: |
           git push origin "${BRANCH}"
           echo "Successfully pushed branch '${BRANCH}'"
+
+      - name: Push temporary branch and create PR
+        if: steps.check-branch.outputs.exists == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+        run: |
+          TEMP_BRANCH="update-${BRANCH}-${TAG}"
+          git push origin "${TEMP_BRANCH}"
+          gh pr create \
+            --base "${BRANCH}" \
+            --head "${TEMP_BRANCH}" \
+            --title "chore: merge ${TAG} into ${BRANCH}" \
+            --body "Automated release update: merges tag ${TAG}, syncs ODH workflows, and sets project version."
+          echo "Successfully created PR to merge '${TEMP_BRANCH}' into '${BRANCH}'"


### PR DESCRIPTION
# What does this PR do?
<!-- Provide a short summary of what this PR does and why. Link to relevant issues if applicable. -->
The `odh-create-or-update-release-branch` workflow pushes directly to release branches, which fails on existing branches due to branch protection requiring changes through pull requests. When the release branch already exists, the workflow should create a PR instead of pushing directly.

<!-- If resolving an issue, uncomment and update the line below -->
<!-- Closes #[issue-number] -->
Closes RHOAIENG-70286.

## Test Plan
<!-- Describe the tests you ran to verify your changes with result summaries. *Provide clear instructions so the plan can be easily re-executed.* -->

<!-- For API changes, include:
1. A testing script (Python, curl, etc.) that exercises the new/modified endpoints
2. The output from running your script

Example:
```python
...
...
```

Output:
```
<paste actual output here>
```
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved release automation to handle existing release branches by creating a temporary branch and opening a pull request automatically.
  * Expanded CI coverage with additional scheduled and security scan workflow entries.
* **Bug Fixes**
  * Updated workflow handling to avoid direct branch pushes when the target release branch already exists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->