### PR TITLE
chore: bump version to 0.4.2.4+rhai0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ constraint-dependencies = [
 
 [project]
 name = "llama_stack"
-version = "0.4.2.3+rhai0"
+version = "0.4.2.4+rhai0"
 authors = [{ name = "Meta Llama", email = "llama-oss@meta.com" }]
 description = "Llama Stack"
 readme = "README.md"


### PR DESCRIPTION
Bump pyproject.toml version for midstream tag. Includes python-multipart>=0.0.27 fix from PR #208 (CVE-2026-42561).